### PR TITLE
Underlying constructor access

### DIFF
--- a/core/src/main/scala/japgolly/scalajs/react/package.scala
+++ b/core/src/main/scala/japgolly/scalajs/react/package.scala
@@ -53,36 +53,36 @@ package object react {
   /**
    * Component constructor. Properties required.
    */
-  class CompCtorP[P, S, B](u: ComponentConstructor[P, S, B], key: Option[JAny]) {
-    def apply(props: P, children: VDom*)      = u(mkProps(props, key), children: _*)
-    def apply2(props: P, children: Seq[VDom]) = u(mkProps(props, key), children: _*)
+  class CompCtorP[P, S, B](val jsCtor: ComponentConstructor[P, S, B], key: Option[JAny]) {
+    def apply(props: P, children: VDom*)      = jsCtor(mkProps(props, key), children: _*)
+    def apply2(props: P, children: Seq[VDom]) = jsCtor(mkProps(props, key), children: _*)
     /** ↑ Workaround for what seems to be a Scala.js bug. ↑ */
 
-    def withKey(key: JAny) = new CompCtorP(u, Some(key))
+    def withKey(key: JAny) = new CompCtorP(jsCtor, Some(key))
   }
 
   /**
    * Component constructor. Properties optional.
    */
-  class CompCtorOP[P, S, B](u: ComponentConstructor[P, S, B], key: Option[JAny], d: () => P) {
+  class CompCtorOP[P, S, B](val jsCtor: ComponentConstructor[P, S, B], key: Option[JAny], d: () => P) {
     def apply(props: Option[P], children: VDom*): ReactComponentU[P, S, B] =
-      u(mkProps(props getOrElse d(), key), children: _*)
+      jsCtor(mkProps(props getOrElse d(), key), children: _*)
 
     def apply(children: VDom*): ReactComponentU[P, S, B] =
       apply(None, children: _*)
 
     /** Workaround for what seems to be a Scala.js bug. */
-    def apply2(props: Option[P], children: Seq[VDom]) = u(mkProps(props getOrElse d(), key), children: _*)
+    def apply2(props: Option[P], children: Seq[VDom]) = jsCtor(mkProps(props getOrElse d(), key), children: _*)
 
-    def withKey(key: JAny) = new CompCtorOP(u, Some(key), d)
+    def withKey(key: JAny) = new CompCtorOP(jsCtor, Some(key), d)
   }
 
   /**
    * Component constructor. Properties not required.
    */
-  class CompCtorNP[P, S, B](u: ComponentConstructor[P, S, B], key: Option[JAny], d: () => P) {
-    def apply(children: VDom*) = u(mkProps(d(), key), children: _*)
-    def withKey(key: JAny) = new CompCtorNP(u, Some(key), d)
+  class CompCtorNP[P, S, B](val jsCtor: ComponentConstructor[P, S, B], key: Option[JAny], d: () => P) {
+    def apply(children: VDom*) = jsCtor(mkProps(d(), key), children: _*)
+    def withKey(key: JAny) = new CompCtorNP(jsCtor, Some(key), d)
   }
 //  class CompCtorNP[Props, State, Backend](u: ComponentConstructor[Props, State, Backend]) {
 //    def apply(children: VDom*) = u(null, children: _*)


### PR DESCRIPTION
This is to support js interop where specific props are expecting a pure react constructor.  There is obviously a more elegant way to do this, but this is useful enough for me.

Below is an example of the interface I am exposing internally, specifically this becomes useful for passing the pure constructor to the handler prop.

``` javascript
var Route = require('react-router').Route;

React.renderComponent((
  <Route handler={App}>
    <Route name="about" handler={About}/>
    <Route name="users" handler={Users}>
      <Route name="user" path="/user/:userId" handler={User}/>
    </Route>
  </Route>
), document.body);
```
