### PR TITLE
Builder now combines (rather than replaces) component lifecycle methods

### DIFF
--- a/core/src/main/scala/japgolly/scalajs/react/ReactComponentB.scala
+++ b/core/src/main/scala/japgolly/scalajs/react/ReactComponentB.scala
@@ -130,7 +130,7 @@ object ReactComponentB {
   }
 
   private def composeUndef[A, B, C, R](f1: UndefOr[(A, B, C) => R], g: (A, B, C) => R) = f1.fold(g) { f => (a: A, b: B, c: C) =>
-    f1.foreach(_(a, b, c))
+    f(a, b, c)
     g(a, b, c)
   }
 }


### PR DESCRIPTION
Addresses idea brought up in #21 by having the builder combine rather than replace component lifecycle methods.

Not sure how/if I can use the same composition function for functions of different arity so I had to add 3 of them.
