### PR TITLE
Adds UnitNode support (same as Scalatags) back.

### DIFF
--- a/core/src/main/scala/japgolly/scalajs/react/vdom/Scalatags.scala
+++ b/core/src/main/scala/japgolly/scalajs/react/vdom/Scalatags.scala
@@ -266,6 +266,14 @@ private[vdom] object Scalatags {
   implicit class SeqNode[A <% TagMod](xs: Seq[A]) extends TagMod {
     def applyTo(t: Builder) = xs.foreach(_.applyTo(t))
   }
+ 
+  /** 
+   * Treats Unit as a no-op in VDOM tree.  Useful when doing partial ifs:
+   * (if (condition) span("Error Message"))
+   */
+  implicit class UnitNode(u: Unit) extends TagMod {
+    def applyTo(t: Builder) = ()
+  }
 }
 
 


### PR DESCRIPTION
Allows partial matches when building your VDOM.  This worked before the Scalatags embedding and presumably just missed along the way:

```
div(
  (if (someThingEnabled) span("some thing")),
  div("always here")
)
```