### PR TITLE
Allow scalatags to accept js.Array as an attribute value

### DIFF
--- a/core/src/main/scala/japgolly/scalajs/react/vdom/Implicits.scala
+++ b/core/src/main/scala/japgolly/scalajs/react/vdom/Implicits.scala
@@ -35,6 +35,9 @@ abstract class Implicits extends LowPri {
   @inline implicit final def _react_attrOptional[T[_], A](implicit t: Optional[T], a: AttrValue[A]): AttrValue[T[A]] =
     new OptionalAttrValue[T, A](t, a)
 
+  @inline implicit final def _react_attrArray[A <% js.Any]: AttrValue[js.Array[A]] =
+    new ArrayAttr[A]
+
   // Styles
   @inline implicit final def _react_styleString : StyleValue[String]  = stringStyleX
           implicit final val _react_styleBoolean: StyleValue[Boolean] = GenericStyle.stringValue

--- a/core/src/main/scala/japgolly/scalajs/react/vdom/Scalatags.scala
+++ b/core/src/main/scala/japgolly/scalajs/react/vdom/Scalatags.scala
@@ -223,6 +223,10 @@ private[vdom] object Scalatags {
     @inline def apply[T <% js.Any] = new GenericAttr[T](a => a)
   }
 
+  final class ArrayAttr[T] extends AttrValue[js.Array[T]] {
+    def apply(v: js.Array[T], b: js.Any => Unit): Unit = b(v)
+  }
+
   final class GenericStyle[T](f: T => String) extends StyleValue[T] {
     def apply(b: Builder, s: Style, v: T): Unit = {
       b.addStyle(s.cssName, f(v))

--- a/test/src/test/scala/japgolly/scalajs/react/CoreTest.scala
+++ b/test/src/test/scala/japgolly/scalajs/react/CoreTest.scala
@@ -3,7 +3,7 @@ package japgolly.scalajs.react
 import japgolly.scalajs.react.Addons.ReactCloneWithProps
 import utest._
 import scala.scalajs.js, js.{Array => JArray}
-import org.scalajs.dom.raw.HTMLInputElement
+import org.scalajs.dom.raw.{HTMLOptionElement, HTMLSelectElement, HTMLInputElement}
 import vdom.all._
 import TestUtil._
 import test.{DebugJs, ReactTestUtils}
@@ -298,6 +298,25 @@ object CoreTest extends TestSuite {
       val c = ReactTestUtils.renderIntoDocument(SI())
       val v = c.getDOMNode().value // Look, it knows its DOM node type
       assert(v == "123")
+    }
+
+    'selectWithMultipleValues {
+      val s = ReactComponentB[Unit]("s")
+        .render(T =>
+          select(multiple := true, value := js.Array("a", "c"))(
+            option(value := "a")("a"),
+            option(value := "b")("b"),
+            option(value := "c")("c")
+          )
+        )
+        .domType[HTMLSelectElement]
+        .buildU
+
+      val c = ReactTestUtils.renderIntoDocument(s())
+      val sel = c.getDOMNode()
+      val options = sel.options.asInstanceOf[js.Array[HTMLOptionElement]] // https://github.com/scala-js/scala-js-dom/pull/107
+      val selectedOptions = options filter (_.selected) map (_.value)
+      assert(selectedOptions.toSet == Set("a", "c"))
     }
 
     'refs {


### PR DESCRIPTION
As stated at http://facebook.github.io/react/docs/forms.html, `value` / `defaultValue` of `multiple` `select` elements can be arrays, so I added support. Working properly on a local build.