### PR TITLE
change TopNode from dom.html.Element to dom.Element

### DIFF
--- a/core/src/main/scala/japgolly/scalajs/react/package.scala
+++ b/core/src/main/scala/japgolly/scalajs/react/package.scala
@@ -6,7 +6,7 @@ import js.{Dynamic, UndefOr, undefined, Object, Any => JAny, Function => JFn}
 
 package object react {
 
-  type TopNode = html.Element
+  type TopNode = dom.Element
 
   type ReactEvent            = SyntheticEvent           [dom.Node]
   type ReactClipboardEvent   = SyntheticClipboardEvent  [dom.Node]
@@ -252,7 +252,10 @@ package object react {
   }
 
   @inline implicit final class ReactExt_UndefReactComponentM[N <: TopNode](val _u: UndefOr[ReactComponentM_[N]]) extends AnyVal {
-    def tryFocus(): Unit = _u.foreach(_.getDOMNode().focus())
+    def tryFocus(): Unit = _u.foreach(_.getDOMNode() match {
+      case e: html.Element => e.focus()
+      case _ =>
+    })
   }
 
   @inline implicit final class ReactExt_ReactComponentM[N <: TopNode](val _c: ReactComponentM_[N]) extends AnyVal {

--- a/test/src/test/scala/japgolly/scalajs/react/CoreTest.scala
+++ b/test/src/test/scala/japgolly/scalajs/react/CoreTest.scala
@@ -3,7 +3,7 @@ package japgolly.scalajs.react
 import japgolly.scalajs.react.Addons.{ReactCssTransitionGroup, ReactCloneWithProps}
 import utest._
 import scala.scalajs.js, js.{Array => JArray}
-import org.scalajs.dom.raw.{HTMLOptionElement, HTMLSelectElement, HTMLInputElement}
+import org.scalajs.dom.raw.{HTMLElement, HTMLOptionElement, HTMLSelectElement, HTMLInputElement}
 import vdom.all._
 import TestUtil._
 import test.{DebugJs, ReactTestUtils}
@@ -400,7 +400,7 @@ object CoreTest extends TestSuite {
           .buildU
         val instance = ReactTestUtils.renderIntoDocument(GrandParent())
         val n = ReactTestUtils.findRenderedDOMComponentWithClass(instance, "xyz").getDOMNode()
-        assert(n.asInstanceOf[js.Dynamic].className == "xyz child")
+        assert(n.matchesBy[HTMLElement](_.className == "xyz child"))
       }
     }
 

--- a/test/src/test/scala/japgolly/scalajs/react/CoreTest.scala
+++ b/test/src/test/scala/japgolly/scalajs/react/CoreTest.scala
@@ -400,7 +400,7 @@ object CoreTest extends TestSuite {
           .buildU
         val instance = ReactTestUtils.renderIntoDocument(GrandParent())
         val n = ReactTestUtils.findRenderedDOMComponentWithClass(instance, "xyz").getDOMNode()
-        assert(n.className == "xyz child")
+        assert(n.asInstanceOf[js.Dynamic].className == "xyz child")
       }
     }
 

--- a/test/src/test/scala/japgolly/scalajs/react/TestUtil.scala
+++ b/test/src/test/scala/japgolly/scalajs/react/TestUtil.scala
@@ -2,6 +2,7 @@ package japgolly.scalajs.react
 
 import java.util.concurrent.atomic.AtomicReference
 import scala.collection.mutable.ListBuffer
+import scala.reflect.ClassTag
 import scala.scalajs.js
 import scalaz.Maybe
 import vdom.all._
@@ -68,6 +69,11 @@ object TestUtil {
 
     def just    : Maybe[A] = Maybe.just(v)
     def maybeNot: Maybe[A] = Maybe.empty
+
+    def matchesBy[B <: A : ClassTag](f: B => Boolean) = v match {
+      case b: B => f(b)
+      case _ => false
+    }
   }
 
   def none[A]: Option[A] = None

--- a/test/src/test/scala/japgolly/scalajs/react/test/TestTest.scala
+++ b/test/src/test/scala/japgolly/scalajs/react/test/TestTest.scala
@@ -1,6 +1,6 @@
 package japgolly.scalajs.react.test
 
-import org.scalajs.dom.raw.HTMLInputElement
+import org.scalajs.dom.raw.{HTMLElement, HTMLInputElement}
 import utest._
 import japgolly.scalajs.react._
 import vdom.all._
@@ -35,12 +35,12 @@ object TestTest extends TestSuite {
 
     'findRenderedDOMComponentWithClass {
       val n = ReactTestUtils.findRenderedDOMComponentWithClass(rab, "BB").getDOMNode()
-      assert(n.asInstanceOf[js.Dynamic].className == "BB")
+      assert(n.matchesBy[HTMLElement](_.className == "BB"))
     }
 
     'findRenderedComponentWithType {
       val n = ReactTestUtils.findRenderedComponentWithType(rab, B).getDOMNode()
-      assert(n.asInstanceOf[js.Dynamic].className == "BB")
+      assert(n.matchesBy[HTMLElement](_.className == "BB"))
     }
 
     'renderIntoDocument {

--- a/test/src/test/scala/japgolly/scalajs/react/test/TestTest.scala
+++ b/test/src/test/scala/japgolly/scalajs/react/test/TestTest.scala
@@ -5,6 +5,7 @@ import utest._
 import japgolly.scalajs.react._
 import vdom.all._
 import TestUtil._
+import scala.scalajs.js
 
 object TestTest extends TestSuite {
 
@@ -34,12 +35,12 @@ object TestTest extends TestSuite {
 
     'findRenderedDOMComponentWithClass {
       val n = ReactTestUtils.findRenderedDOMComponentWithClass(rab, "BB").getDOMNode()
-      assert(n.className == "BB")
+      assert(n.asInstanceOf[js.Dynamic].className == "BB")
     }
 
     'findRenderedComponentWithType {
       val n = ReactTestUtils.findRenderedComponentWithType(rab, B).getDOMNode()
-      assert(n.className == "BB")
+      assert(n.asInstanceOf[js.Dynamic].className == "BB")
     }
 
     'renderIntoDocument {


### PR DESCRIPTION
React has decent support for svg components. Setting TopNode to dom.Element would allow properly typed getDOMNode access of svg elements (in both component building and refs), given that its only subtypes are HTMLElement and SVGElement.

As an aside: className seems to have been misplaced in the dom facade, requiring a small workaround (it should be in dom.Element according to https://developer.mozilla.org/en-US/docs/Web/API/Element/className).