### PR TITLE
ListenableBuilder

### DIFF
--- a/core/src/main/scala/japgolly/scalajs/react/ReactComponentB.scala
+++ b/core/src/main/scala/japgolly/scalajs/react/ReactComponentB.scala
@@ -1,5 +1,7 @@
 package japgolly.scalajs.react
 
+import japgolly.scalajs.react.ReactComponentC.ReqProps
+
 import scala.scalajs.js.{Any => JAny, Array => JArray, _}
 import Internal._
 
@@ -10,9 +12,14 @@ object ReactComponentB {
 
   @inline def apply[Props](name: String) = new P[Props](name)
 
-  implicit def defaultDomType[P,S,B](c: PSBN[P,S,B]) = c.domType[TopNode]
-  implicit def defaultProps[P,S,B,N <: TopNode](c: ReactComponentB[P,S,B,N]) = c.propsRequired
-  implicit def defaultDomTypeAndProps[P,S,B](c: PSBN[P,S,B]) = defaultProps(defaultDomType(c))
+  implicit def defaultDomType[P,S,B](c: PSBN[P,S,B]): ReactComponentB[P, S, B, TopNode] =
+    c.domType[TopNode]
+
+  implicit def defaultProps[P,S,B,N <: TopNode](c: ReactComponentB[P,S,B,N]): c.Builder[ReqProps[P, S, B, N]] =
+    c.propsRequired
+
+  implicit def defaultDomTypeAndProps[P,S,B](c: PSBN[P,S,B]): ReactComponentB[P, S, B, TopNode]#Builder[ReqProps[P, S, B, TopNode]] =
+    defaultProps(defaultDomType(c))
 
   // ===================================================================================================================
   // Convenience

--- a/extra/src/main/scala/japgolly/scalajs/react/extra/Listenable.scala
+++ b/extra/src/main/scala/japgolly/scalajs/react/extra/Listenable.scala
@@ -20,7 +20,7 @@ trait Listenable[A] {
   def register(f: A => Unit): () => Unit
 }
 
-object Listenable {
+@deprecated("Use import japgolly.scalajs.react.extra._; component.listenTo() instead", "2015-06-07") object Listenable {
 
   def install[P, S, B <: OnUnmount, N <: TopNode, A](f: P => Listenable[A], g: ComponentScopeM[P, S, B, N] => A => Unit) =
     OnUnmount.install compose ((_: ReactComponentB[P, S, B, N])
@@ -34,5 +34,4 @@ object Listenable {
 
   def installSF[P, S, B <: OnUnmount, N <: TopNode, M[_], A](f: P => Listenable[A], g: A => ReactST[M, S, Unit])(implicit M: M ~> IO, F: ChangeFilter[S]) =
     installIO[P, S, B, N, A](f, (t, a) => t.runStateF(g(a)))
-
 }

--- a/extra/src/main/scala/japgolly/scalajs/react/extra/ListenableB1.scala
+++ b/extra/src/main/scala/japgolly/scalajs/react/extra/ListenableB1.scala
@@ -1,0 +1,67 @@
+package japgolly.scalajs.react.extra
+
+import japgolly.scalajs.react.ScalazReact._
+import japgolly.scalajs.react._
+
+import scalaz._
+import scalaz.effect.IO
+
+final case class ListenableB1[P, S, B <: OnUnmount, N <: TopNode, A]
+                             (    c: ReactComponentB[P, S, B, N])
+                             (val f: P => Listenable[A]) { outer ⇒
+  
+  private type Comp = ReactComponentB[P, S, B, N]
+
+  private[this] def handleEvent(g: (ComponentScopeM[P, S, B, N], A) => Unit): Comp =
+    c.componentDidMount($ => $.backend onUnmountF f($.props).register(a ⇒ g($, a)))
+     .configure(OnUnmount.install)
+
+  private[this] def handleEventIO(g: (ComponentScopeM[P, S, B, N], A) => IO[Unit]): Comp =
+    handleEvent(($, a) => g($, a).unsafePerformIO())
+
+  sealed class ListenableB2[In](mapIn: ((ComponentScopeM[P, S, B, N], A)) ⇒ In){
+    def handleEvent(g: In => Unit): Comp =
+      outer.handleEvent(($, a) ⇒ g(mapIn(($, a))))
+
+    def handleEventIO(g: In => IO[Unit]): Comp =
+      handleEvent(in => g(in).unsafePerformIO())
+
+    def handleEventS[M[_]](g: In => ReactST[M, S, Unit])(implicit M: M ~> IO): Comp =
+      outer.handleEventIO{case (t, a) => t.runState(g(mapIn(t, a)))}
+
+    def handleEventSF[M[_]](g: In => ReactST[M, S, Unit])(implicit M: M ~> IO, F: ChangeFilter[S]): Comp =
+      outer.handleEventIO{case (t, a) => t.runStateF(g(mapIn(t, a)))}
+  }
+
+  object ignoringProps   extends ListenableB2[A](c ⇒ c._2)
+  object ignoringData    extends ListenableB2[ComponentScopeM[P, S, B, N]](_._1)
+  object ignoringNothing extends ListenableB2[(ComponentScopeM[P, S, B, N], A)](identity)
+
+  object ignoringInput /* ListenableB2[Unit](_ => ()) //can not abstract over by-names, so inlining */ {
+    def handleEvent(g: ⇒ Unit): Comp =
+      outer.handleEvent((_, _) ⇒ g)
+
+    def handleEventIO(g: => IO[Unit]): Comp =
+      handleEvent(g.unsafePerformIO())
+
+    def handleEventS[M[_]](g: => ReactST[M, S, Unit])(implicit M: M ~> IO): Comp =
+      outer.handleEventIO{case (t, _) => t.runState(g)}
+
+    def handleEventSF[M[_]](g: => ReactST[M, S, Unit])(implicit M: M ~> IO, F: ChangeFilter[S]): Comp =
+      outer.handleEventIO{case (t, _) => t.runStateF(g)}
+  }
+}
+
+trait ListenableBuilderSyntax {
+  implicit final class ReactComponentBListener[P, S, B <: OnUnmount, N <: TopNode, C]
+                                              (val        c: C)
+                                              (implicit ev1: C ⇒ ReactComponentB[P, S, B, N]) {
+    def listenToFromProps[A](f: P => Listenable[A]): ListenableB1[P, S, B, N, A] =
+      ListenableB1[P, S, B, N, A](c)(f)
+
+    def listenTo[A](f: Listenable[A]): ListenableB1[P, S, B, N, A] =
+      listenToFromProps(_ ⇒ f)
+  }
+}
+
+object listenTo extends ListenableBuilderSyntax

--- a/extra/src/main/scala/japgolly/scalajs/react/extra/extra.scala
+++ b/extra/src/main/scala/japgolly/scalajs/react/extra/extra.scala
@@ -3,7 +3,7 @@ package japgolly.scalajs.react
 import scala.annotation.elidable
 import org.scalajs.dom
 
-package object extra {
+package object extra extends ListenableBuilderSyntax {
 
   @elidable(elidable.ASSERTION)
   def assertWarn(test: => Boolean, msg: => String): Unit =
@@ -16,5 +16,4 @@ package object extra {
     def ~=~(a: A)(implicit r: Reusability[A]): Boolean = r.test(self, a)
     def ~/~(a: A)(implicit r: Reusability[A]): Boolean = !r.test(self, a)
   }
-
 }

--- a/extra/src/main/scala/japgolly/scalajs/react/extra/router/Router.scala
+++ b/extra/src/main/scala/japgolly/scalajs/react/extra/router/Router.scala
@@ -19,7 +19,7 @@ object Router {
       .backend             (_ => new OnUnmount.Backend)
       .render              ((_, route, _) => route.render(router))
       .componentWillMountIO(router.init)
-      .configure(Listenable.installSF(_ => router, (_: Unit) => router.syncToWindowUrlS))
+      .listenTo(router).ignoringInput.handleEventSF(router.syncToWindowUrlS)
 
   def component[P](router: Router[P]): Component[P] =
     componentUnbuilt(router).buildU

--- a/extra/src/main/scala/japgolly/scalajs/react/extra/router2/Router.scala
+++ b/extra/src/main/scala/japgolly/scalajs/react/extra/router2/Router.scala
@@ -22,9 +22,10 @@ object Router {
       .render              ((_,s,_) => lgc.render(s))
       .componentDidMountIO ($       => cfg.postRenderFn(None, $.state.page))
       .componentDidUpdateIO(($,_,p) => cfg.postRenderFn(Some(p.page), $.state.page))
+      .listenTo(lgc).ignoringInput.handleEventS(lgc.syncToWindowUrlS)
       .configure(
-        EventListener.installIO("popstate", _ => lgc.ctl.refresh, _ => dom.window),
-        Listenable.installS(_ => lgc, (_: Unit) => lgc.syncToWindowUrlS))
+        EventListener.installIO("popstate", _ => lgc.ctl.refresh, _ => dom.window)
+      )
 
   def componentAndLogic[Page](baseUrl: BaseUrl, cfg: RouterConfig[Page]): (Router[Page], RouterLogic[Page]) = {
     val l = new RouterLogic(baseUrl, cfg)

--- a/gh-pages/src/main/scala/ghpages/ExtrasExamples.scala
+++ b/gh-pages/src/main/scala/ghpages/ExtrasExamples.scala
@@ -68,7 +68,7 @@ object ExtrasExamples {
       .initialState(0)
       .backend(_ => new Backend)
       .render((_,s,_) => div("Total: ", s))
-      .configure(Listenable.installS(identity, recv))   // Listen to events when mounted.
+      .listenToFromProps(identity).ignoringProps.handleEventS(recv) // Listen to events when mounted.
       .build
   }
 }


### PR DESCRIPTION
So, i had some problems configuring my components to listen to events.

My main complaint is that `Listenable.install` needs access to the full types of the `ComponentScopeM` and the type parameter of the `Broadcaster[A]`, yet doesn't have a place to get them.

This means that i ended up manually annotating types like this:
```scala
component.configure(Listenable.install(_ => model, ($: ComponentScopeM[Props, State, Backend, TopNode]) => (_: Unit) => $.forceUpdate()))
```

With changes like the ones im proposing, this ends up like this:
```scala
component.listenToFromProps(_.model).ignoringData.handleEvent(_.forceUpdate())
```


I havent looked at all at `EventListener`, it would be even better if we could manage to get a uniform API for listening to dom events as well.

What do you think?