### PR TITLE
More specific jsDependency

### DIFF
--- a/doc/USAGE.md
+++ b/doc/USAGE.md
@@ -27,7 +27,7 @@ Setup
   libraryDependencies += "com.github.japgolly.scalajs-react" %%% "core" % "0.9.2"
 
   // React.JS itself
-  // Note the JS filename. Can also be react.js, react.min.js, or react-with-addons.min.js.
+  // Note the JS filename. Can also be "react/0.12.2/react.js", "react.min.js", or "react-with-addons.min.js".
   jsDependencies +=
     "org.webjars" % "react" % "0.12.2" / "react-with-addons.js" commonJSName "React"
   ```


### PR DESCRIPTION
When I tried using just "react.js" this in a Play project I got this error:
JSLibResolveException: Some references to JS libraries could not be resolved:
- Ambiguous reference to a JS library: react.js
Possible paths found on the classpath:
- META-INF/resources/webjars/react/0.12.2/vendor/fbtransform/transforms/react.js
- META-INF/resources/webjars/react/0.12.2/react.js
originating from: client:compile
Specifying the more specific path solved it.