### PR TITLE
withFilter for CallbackOption to enable if in for comprehensions

### DIFF
--- a/core/src/main/scala/japgolly/scalajs/react/CallbackOption.scala
+++ b/core/src/main/scala/japgolly/scalajs/react/CallbackOption.scala
@@ -137,6 +137,9 @@ final class CallbackOption[A](private val cbfn: () => Option[A]) extends AnyVal 
   def filter(condition: A => Boolean): CallbackOption[A] =
     CallbackOption(get.map(_ filter condition))
 
+  def withFilter(condition: A => Boolean): CallbackOption[A] =
+    filter(condition)
+
   /**
    * Sequence a callback to run after this, discarding any value produced by this.
    */


### PR DESCRIPTION
Hah, i was coing to contribute a `zip` for `Callback` and `CallbackOption` - seems you beat me to it. That leaves this:

`withFilter` is to use ifs for `CallbackOption` in for comprehensions without a warning (breaks my build since im normally using most of https://tpolecat.github.io/2014/04/11/scalac-flags.html )