### PR TITLE
Re-throw errors when discarding results via Callback.future

### DIFF
--- a/doc/changelog/0.10.4.md
+++ b/doc/changelog/0.10.4.md
@@ -1,0 +1,6 @@
+## 0.10.4 ([commit log](https://github.com/japgolly/scalajs-react/compare/v0.10.4...v0.10.4))
+
+##### Changes
+
+* Re-throw captured exceptions inside Callback.future
+


### PR DESCRIPTION
Per discussion on gitter, this re-throws exceptions that are otherwise thrown out by Callback.future. I think this implementation less violates the principle of least surprise, but happy to discuss =p