### PR TITLE
Provide safer BaseUrl.fromWindowLocation methods

### DIFF
--- a/doc/changelog/0.10.5.md
+++ b/doc/changelog/0.10.5.md
@@ -10,3 +10,4 @@
 * Add new Router DSL:
   * `remainingPath` - Captures the (non-empty) remaining portion of the URL path.
   * `remainingPathOrBlank` - Captures the (potentially-empty) remaining portion of the URL path.
+* Replace BaseUrl.fromWindowOrigin with a more IE-friendly implementation that does not use location.origin

--- a/extra/src/main/scala/japgolly/scalajs/react/extra/router/types.scala
+++ b/extra/src/main/scala/japgolly/scalajs/react/extra/router/types.scala
@@ -40,8 +40,13 @@ final case class BaseUrl(value: String) extends PathLike[BaseUrl] {
 }
 
 object BaseUrl {
-  def fromWindowOrigin: BaseUrl =
-    BaseUrl(dom.window.location.origin)
+  def fromWindowOrigin: BaseUrl = {
+    val l = dom.window.location
+    var url = l.protocol + "/" + l.hostname
+    if (!l.port.matches("^(?:80)?$"))
+      url += ":" + l.port
+    BaseUrl(url)
+  }
 
   def fromWindowOrigin_/ : BaseUrl =
     fromWindowOrigin.endWith_/


### PR DESCRIPTION
- IE doesn't properly support BaseUrl.fromWindowOrigin, so until the scala-js-dom facade
  represents the possible undefined state for dom.window.location.origin, one can use this
  method which can be used a fallback once the dom type is updated

Fixes #249