### PR TITLE
`assert` had to be `assertHtml` in Test Documentation

### DIFF
--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -133,10 +133,10 @@ ComponentTester(Example)("First props") { tester =>
   assertHtml("First props", 0)
 
   setState(2)
-  assert("First props", 2)
+  assertHtml("First props", 2)
 
   setProps("Second props")
-  assert("Second props", 2)
+  assertHtml("Second props", 2)
 }
 ```
 


### PR DESCRIPTION
This seems to fix the example. I am having trouble with my component that doesn't take any props for that example so any help with that would be nice.