### PR TITLE
Import ReactTestUtils from react-addons-test-utils

### DIFF
--- a/test/src/main/scala/japgolly/scalajs/react/test/ReactTestUtils.scala
+++ b/test/src/main/scala/japgolly/scalajs/react/test/ReactTestUtils.scala
@@ -7,7 +7,6 @@ import japgolly.scalajs.react._
 
 /** https://facebook.github.io/react/docs/test-utils.html */
 @js.native
-@JSName("React.addons.TestUtils")
 object ReactTestUtils extends ReactTestUtils
 
 @js.native


### PR DESCRIPTION
React team recommens to import addons explicitly.  https://facebook.github.io/react/docs/test-utils.html
