### PR TITLE
SVG tags are case sensitive

### DIFF
--- a/core/src/main/scala/japgolly/scalajs/react/vdom/SvgTags.scala
+++ b/core/src/main/scala/japgolly/scalajs/react/vdom/SvgTags.scala
@@ -590,7 +590,7 @@ trait SvgTags {
    *
    * MDN
    */
-  final lazy val title = "textPath".tag[*.Title]
+  final lazy val title = "title".tag[*.Title]
   /**
    * The textual content for a text can be either character data directly
    * embedded within the text element or the character data content of a

--- a/core/src/main/scala/japgolly/scalajs/react/vdom/SvgTags.scala
+++ b/core/src/main/scala/japgolly/scalajs/react/vdom/SvgTags.scala
@@ -64,7 +64,7 @@ trait SvgTags {
    *
    * MDN
    */
-  final lazy val clipPath = "clipPath".tag[*.ClipPath]
+  final lazy val clipPathTag = "clipPath".tag[*.ClipPath]
   /**
    * The element allows describing the color profile used for the image.
    *
@@ -80,7 +80,7 @@ trait SvgTags {
    *
    * MDN
    */
-  final lazy val cursor = "cursor".tag[*.Element]
+  final lazy val cursorTag = "cursor".tag[*.Element]
   /**
    * SVG allows graphical objects to be defined for later reuse. It is
    * recommended that, wherever possible, referenced elements be defined inside
@@ -307,7 +307,7 @@ trait SvgTags {
    *
    * MDN
    */
-  final lazy val filter = "filter".tag[*.Filter]
+  final lazy val filterTag = "filter".tag[*.Filter]
   /**
    * The font element defines a font to be used for text layout.
    *
@@ -425,7 +425,7 @@ trait SvgTags {
    *
    * MDN
    */
-  final lazy val mask = "mask".tag[*.Mask]
+  final lazy val maskTag = "mask".tag[*.Mask]
   /**
    * Metadata is structured data about data. Metadata which is included with SVG
    * content should be specified within metadata elements. The contents of the

--- a/core/src/main/scala/japgolly/scalajs/react/vdom/SvgTags.scala
+++ b/core/src/main/scala/japgolly/scalajs/react/vdom/SvgTags.scala
@@ -14,12 +14,16 @@ trait SvgTags {
    * MDN
    */
   final lazy val altGlyph = "altGlyph".tag[*.Element]
+  @deprecated("SvgTags now use camelCase.", "0.11.2")
+  final def altglyph = altGlyph
   /**
    * The altGlyphDef element defines a substitution representation for glyphs.
    *
    * MDN
    */
   final lazy val altGlyphDef = "altGlyphDef".tag[*.Element]
+  @deprecated("SvgTags now use camelCase.", "0.11.2")
+  final def altglyphdef = altGlyphDef
 
   /**
    * The altGlyphItem element provides a set of candidates for glyph substitution
@@ -28,6 +32,8 @@ trait SvgTags {
    * MDN
    */
   final lazy val altGlyphItem = "altGlyphItem".tag[*.Element]
+  @deprecated("SvgTags now use camelCase.", "0.11.2")
+  final def altglyphitem = altGlyphItem
   /**
    * The animate element is put inside a shape element and defines how an
    * attribute of an element changes over the animation
@@ -42,6 +48,8 @@ trait SvgTags {
    * MDN
    */
   final lazy val animateMotion = "animateMotion".tag[*.Element]
+  @deprecated("SvgTags now use camelCase.", "0.11.2")
+  final def animatemotion = animateMotion
   /**
    * The animateTransform element animates a transformation attribute on a target
    * element, thereby allowing animations to control translation, scaling,
@@ -50,6 +58,8 @@ trait SvgTags {
    * MDN
    */
   final lazy val animateTransform = "animateTransform".tag[*.Element]
+  @deprecated("SvgTags now use camelCase.", "0.11.2")
+  final def animatetransform = animateTransform
   /**
    * The circle element is an SVG basic shape, used to create circles based on a
    * center point and a radius.
@@ -65,6 +75,8 @@ trait SvgTags {
    * MDN
    */
   final lazy val clipPathTag = "clipPath".tag[*.ClipPath]
+  @deprecated("SvgTags now use camelCase.", "0.11.2")
+  final def clippath = clipPathTag
   /**
    * The element allows describing the color profile used for the image.
    *
@@ -127,6 +139,8 @@ trait SvgTags {
    * MDN
    */
   final lazy val feBlend = "feBlend".tag[*.FEBlend]
+  @deprecated("SvgTags now use camelCase.", "0.11.2")
+  final def feblend = feBlend
   /**
    * This filter changes colors based on a transformation matrix. Every pixel's
    * color value (represented by an [R,G,B,A] vector) is matrix multiplied to
@@ -135,6 +149,8 @@ trait SvgTags {
    * MDN
    */
   final lazy val feColorMatrix = "feColorMatrix".tag[*.FEColorMatrix]
+  @deprecated("SvgTags now use camelCase.", "0.11.2")
+  final def fecolormatrix = feColorMatrix
   /**
    * The color of each pixel is modified by changing each channel (R, G, B, and
    * A) to the result of what the children fefuncr, fefuncb, fefuncg,
@@ -143,6 +159,8 @@ trait SvgTags {
    * MDN
    */
   final lazy val feComponentTransfer = "feComponentTransfer".tag[*.ComponentTransferFunction]
+  @deprecated("SvgTags now use camelCase.", "0.11.2")
+  final def fecomponenttransfer = feComponentTransfer
   /**
    * This filter primitive performs the combination of two input images pixel-wise
    * in image space using one of the Porter-Duff compositing operations: over,
@@ -152,6 +170,8 @@ trait SvgTags {
    * MDN
    */
   final lazy val feComposite = "feComposite".tag[*.FEComposite]
+  @deprecated("SvgTags now use camelCase.", "0.11.2")
+  final def fecomposite = feComposite
   /**
    * the feConvolveMatrix element applies a matrix convolution filter effect.
    * A convolution combines pixels in the input image with neighboring pixels
@@ -162,6 +182,8 @@ trait SvgTags {
    * MDN
    */
   final lazy val feConvolveMatrix = "feConvolveMatrix".tag[*.FEConvolveMatrix]
+  @deprecated("SvgTags now use camelCase.", "0.11.2")
+  final def feconvolvematrix = feConvolveMatrix
   /**
    * This filter primitive lights an image using the alpha channel as a bump map.
    * The resulting image, which is an RGBA opaque image, depends on the light
@@ -170,6 +192,8 @@ trait SvgTags {
    * MDN
    */
   final lazy val feDiffuseLighting = "feDiffuseLighting".tag[*.FEDiffuseLighting]
+  @deprecated("SvgTags now use camelCase.", "0.11.2")
+  final def fediffuselighting = feDiffuseLighting
   /**
    * This filter primitive uses the pixels values from the image from in2 to
    * spatially displace the image from in.
@@ -177,6 +201,8 @@ trait SvgTags {
    * MDN
    */
   final lazy val feDisplacementMap = "feDisplacementMap".tag[*.FEDisplacementMap]
+  @deprecated("SvgTags now use camelCase.", "0.11.2")
+  final def fedisplacementmap = feDisplacementMap
   /**
    * This filter primitive define a distant light source that can be used
    * within a lighting filter primitive: fediffuselighting or
@@ -185,6 +211,8 @@ trait SvgTags {
    * MDN
    */
   final lazy val feDistantLight = "feDistantLight".tag[*.FEDistantLight]
+  @deprecated("SvgTags now use correct camelCase spelling.", "0.11.2")
+  final def fedistantlighting = feDistantLight
   /**
    * The filter fills the filter subregion with the color and opacity defined by
    * flood-color and flood-opacity.
@@ -192,6 +220,8 @@ trait SvgTags {
    * MDN
    */
   final lazy val feFlood = "feFlood".tag[*.FEFlood]
+  @deprecated("SvgTags now use camelCase.", "0.11.2")
+  final def feflood = feFlood
   /**
    * This filter primitive defines the transfer function for the alpha component
    * of the input graphic of its parent fecomponenttransfer element.
@@ -199,6 +229,8 @@ trait SvgTags {
    * MDN
    */
   final lazy val feFuncA = "feFuncA".tag[*.FEFuncA]
+  @deprecated("SvgTags now use camelCase.", "0.11.2")
+  final def fefunca = feFuncA
   /**
    * This filter primitive defines the transfer function for the blue component
    * of the input graphic of its parent fecomponenttransfer element.
@@ -206,6 +238,8 @@ trait SvgTags {
    * MDN
    */
   final lazy val feFuncB = "feFuncB".tag[*.FEFuncB]
+  @deprecated("SvgTags now use camelCase.", "0.11.2")
+  final def fefuncb = feFuncB
   /**
    * This filter primitive defines the transfer function for the green component
    * of the input graphic of its parent fecomponenttransfer element.
@@ -213,6 +247,8 @@ trait SvgTags {
    * MDN
    */
   final lazy val feFuncG = "feFuncG".tag[*.FEFuncG]
+  @deprecated("SvgTags now use camelCase.", "0.11.2")
+  final def fefuncg = feFuncG
   /**
    * This filter primitive defines the transfer function for the red component
    * of the input graphic of its parent fecomponenttransfer element.
@@ -220,14 +256,17 @@ trait SvgTags {
    * MDN
    */
   final lazy val feFuncR = "feFuncR".tag[*.FEFuncR]
+  @deprecated("SvgTags now use camelCase.", "0.11.2")
+  final def fefuncr = feFuncR
   /**
    * The filter blurs the input image by the amount specified in stdDeviation,
    * which defines the bell-curve.
    *
    * MDN
    */
-  final lazy val feFaussianBlur = "feFaussianBlur".tag[*.FEGaussianBlur]
-
+  final lazy val feGaussianBlur = "feGaussianBlur".tag[*.FEGaussianBlur]
+  @deprecated("SvgTags now use camelCase.", "0.11.2")
+  final def fegaussianblur = feGaussianBlur
   /**
    * The feImage filter fetches image data from an external source and provides
    * the pixel data as output (meaning, if the external source is an SVG image,
@@ -236,7 +275,8 @@ trait SvgTags {
    * MDN
    */
   final lazy val feImage = "feImage".tag[*.FEImage]
-
+  @deprecated("SvgTags now use camelCase.", "0.11.2")
+  final def feimage = feImage
   /**
    * The feMerge filter allows filter effects to be applied concurrently
    * instead of sequentially. This is achieved by other filters storing their
@@ -246,7 +286,8 @@ trait SvgTags {
    * MDN
    */
   final lazy val feMerge = "feMerge".tag[*.FEMerge]
-
+  @deprecated("SvgTags now use camelCase.", "0.11.2")
+  final def femerge = feMerge
   /**
    * The feMergeNode takes the result of another filter to be processed by its
    * parent femerge.
@@ -254,6 +295,8 @@ trait SvgTags {
    * MDN
    */
   final lazy val feMergeNode = "feMergeNode".tag[*.FEMergeNode]
+  @deprecated("SvgTags now use camelCase.", "0.11.2")
+  final def femergenode = feMergeNode
   /**
    * This filter is used to erode or dilate the input image. It's usefulness
    * lies especially in fattening or thinning effects.
@@ -261,6 +304,8 @@ trait SvgTags {
    * MDN
    */
   final lazy val feMorphology = "feMorphology".tag[*.FEMorphology]
+  @deprecated("SvgTags now use camelCase.", "0.11.2")
+  final def femorphology = feMorphology
   /**
    * The input image as a whole is offset by the values specified in the dx
    * and dy attributes. It's used in creating drop-shadows.
@@ -268,7 +313,14 @@ trait SvgTags {
    * MDN
    */
   final lazy val feOffset = "feOffset".tag[*.FEOffset]
+  @deprecated("SvgTags now use camelCase.", "0.11.2")
+  final def feoffset = feOffset
+  /**
+   *
+   */
   final lazy val fePointLight = "fePointLight".tag[*.FEPointLight]
+  @deprecated("SvgTags now use camelCase.", "0.11.2")
+  final def fepointlight = fePointLight
   /**
    * This filter primitive lights a source graphic using the alpha channel as a
    * bump map. The resulting image is an RGBA image based on the light color.
@@ -281,10 +333,14 @@ trait SvgTags {
    * MDN
    */
   final lazy val feSpecularLighting = "feSpecularLighting".tag[*.FESpecularLighting]
+  @deprecated("SvgTags now use camelCase.", "0.11.2")
+  final def fespecularlighting = feSpecularLighting
   /**
    *
    */
   final lazy val feSpotLight = "feSpotLight".tag[*.FESpotLight]
+  @deprecated("SvgTags now use camelCase.", "0.11.2")
+  final def fespotlight = feSpotLight
   /**
    * An input image is tiled and the result used to fill a target. The effect
    * is similar to the one of a pattern.
@@ -292,6 +348,8 @@ trait SvgTags {
    * MDN
    */
   final lazy val feTile = "feTile".tag[*.FETile]
+  @deprecated("SvgTags now use camelCase.", "0.11.2")
+  final def fetile = feTile
   /**
    * This filter primitive creates an image using the Perlin turbulence
    * function. It allows the synthesis of artificial textures like clouds or
@@ -299,7 +357,9 @@ trait SvgTags {
    *
    * MDN
    */
-  final lazy val feTurbulance = "feTurbulance".tag[*.FETurbulence]
+  final lazy val feTurbulence = "feTurbulence".tag[*.FETurbulence]
+  @deprecated("SvgTags now use correct camelCase spelling.", "0.11.2")
+  final def feturbulance = feTurbulence
   /**
    * The filter element serves as container for atomic filter operations. It is
    * never rendered directly. A filter is referenced by using the filter
@@ -359,6 +419,8 @@ trait SvgTags {
    * MDN
    */
   final lazy val foreignObject = "foreignObject".tag[*.Element]
+  @deprecated("SvgTags now use camelCase.", "0.11.2")
+  final def foreignobject = foreignObject
   /**
    * The g element is a container used to group objects. Transformations applied
    * to the g element are performed on all of its child elements. Attributes
@@ -381,6 +443,8 @@ trait SvgTags {
    * MDN
    */
   final lazy val glyphRef = "glyphRef".tag[*.Element]
+  @deprecated("SvgTags now use camelCase.", "0.11.2")
+  final def glyphref = glyphRef
   /**
    * The horizontal distance between two glyphs can be fine-tweaked with an
    * hkern Element. This process is known as Kerning.
@@ -409,6 +473,8 @@ trait SvgTags {
    * MDN
    */
   final lazy val linearGradient = "linearGradient".tag[*.LinearGradient]
+  @deprecated("SvgTags now use camelCase.", "0.11.2")
+  final def lineargradient = linearGradient
   /**
    * The marker element defines the graphics that is to be used for drawing
    * arrowheads or polymarkers on a given path, line, polyline or
@@ -487,6 +553,8 @@ trait SvgTags {
    * MDN
    */
   final lazy val radialGradient = "radialGradient".tag[*.RadialGradient]
+  @deprecated("SvgTags now use camelCase.", "0.11.2")
+  final def radialgradient = radialGradient
   /**
    * The rect element is an SVG basic shape, used to create rectangles based on
    * the position of a corner and their width and height. It may also be used to

--- a/core/src/main/scala/japgolly/scalajs/react/vdom/SvgTags.scala
+++ b/core/src/main/scala/japgolly/scalajs/react/vdom/SvgTags.scala
@@ -13,13 +13,13 @@ trait SvgTags {
    *
    * MDN
    */
-  final lazy val altglyph = "altglyph".tag[*.Element]
+  final lazy val altGlyph = "altGlyph".tag[*.Element]
   /**
    * The altGlyphDef element defines a substitution representation for glyphs.
    *
    * MDN
    */
-  final lazy val altglyphdef = "altglyphdef".tag[*.Element]
+  final lazy val altGlyphDef = "altGlyphDef".tag[*.Element]
 
   /**
    * The altGlyphItem element provides a set of candidates for glyph substitution
@@ -27,7 +27,7 @@ trait SvgTags {
    *
    * MDN
    */
-  final lazy val altglyphitem = "altglyphitem".tag[*.Element]
+  final lazy val altGlyphItem = "altGlyphItem".tag[*.Element]
   /**
    * The animate element is put inside a shape element and defines how an
    * attribute of an element changes over the animation
@@ -41,7 +41,7 @@ trait SvgTags {
    *
    * MDN
    */
-  final lazy val animatemotion = "animatemotion".tag[*.Element]
+  final lazy val animateMotion = "animateMotion".tag[*.Element]
   /**
    * The animateTransform element animates a transformation attribute on a target
    * element, thereby allowing animations to control translation, scaling,
@@ -49,7 +49,7 @@ trait SvgTags {
    *
    * MDN
    */
-  final lazy val animatetransform = "animatetransform".tag[*.Element]
+  final lazy val animateTransform = "animateTransform".tag[*.Element]
   /**
    * The circle element is an SVG basic shape, used to create circles based on a
    * center point and a radius.
@@ -64,7 +64,7 @@ trait SvgTags {
    *
    * MDN
    */
-  final lazy val clippath = "clippath".tag[*.ClipPath]
+  final lazy val clipPath = "clipPath".tag[*.ClipPath]
   /**
    * The element allows describing the color profile used for the image.
    *
@@ -80,7 +80,7 @@ trait SvgTags {
    *
    * MDN
    */
-  final lazy val cursorTag = "cursor".tag[*.Element]
+  final lazy val cursor = "cursor".tag[*.Element]
   /**
    * SVG allows graphical objects to be defined for later reuse. It is
    * recommended that, wherever possible, referenced elements be defined inside
@@ -105,6 +105,9 @@ trait SvgTags {
    * MDN
    */
   final lazy val desc = "desc".tag[*.Desc]
+
+  // TODO: Add discard tag (not available in scalajs-dom)
+
   /**
    * The ellipse element is an SVG basic shape, used to create ellipses based
    * on a center coordinate, and both their x and y radius.
@@ -123,7 +126,7 @@ trait SvgTags {
    *
    * MDN
    */
-  final lazy val feblend = "feblend".tag[*.FEBlend]
+  final lazy val feBlend = "feBlend".tag[*.FEBlend]
   /**
    * This filter changes colors based on a transformation matrix. Every pixel's
    * color value (represented by an [R,G,B,A] vector) is matrix multiplied to
@@ -131,7 +134,7 @@ trait SvgTags {
    *
    * MDN
    */
-  final lazy val fecolormatrix = "fecolormatrix".tag[*.FEColorMatrix]
+  final lazy val feColorMatrix = "feColorMatrix".tag[*.FEColorMatrix]
   /**
    * The color of each pixel is modified by changing each channel (R, G, B, and
    * A) to the result of what the children fefuncr, fefuncb, fefuncg,
@@ -139,7 +142,7 @@ trait SvgTags {
    *
    * MDN
    */
-  final lazy val fecomponenttransfer = "fecomponenttransfer".tag[*.ComponentTransferFunction]
+  final lazy val feComponentTransfer = "feComponentTransfer".tag[*.ComponentTransferFunction]
   /**
    * This filter primitive performs the combination of two input images pixel-wise
    * in image space using one of the Porter-Duff compositing operations: over,
@@ -148,7 +151,7 @@ trait SvgTags {
    *
    * MDN
    */
-  final lazy val fecomposite = "fecomposite".tag[*.FEComposite]
+  final lazy val feComposite = "feComposite".tag[*.FEComposite]
   /**
    * the feConvolveMatrix element applies a matrix convolution filter effect.
    * A convolution combines pixels in the input image with neighboring pixels
@@ -158,7 +161,7 @@ trait SvgTags {
    *
    * MDN
    */
-  final lazy val feconvolvematrix = "feconvolvematrix".tag[*.FEConvolveMatrix]
+  final lazy val feConvolveMatrix = "feConvolveMatrix".tag[*.FEConvolveMatrix]
   /**
    * This filter primitive lights an image using the alpha channel as a bump map.
    * The resulting image, which is an RGBA opaque image, depends on the light
@@ -166,14 +169,14 @@ trait SvgTags {
    *
    * MDN
    */
-  final lazy val fediffuselighting = "fediffuselighting".tag[*.FEDiffuseLighting]
+  final lazy val feDiffuseLighting = "feDiffuseLighting".tag[*.FEDiffuseLighting]
   /**
    * This filter primitive uses the pixels values from the image from in2 to
    * spatially displace the image from in.
    *
    * MDN
    */
-  final lazy val fedisplacementmap = "fedisplacementmap".tag[*.FEDisplacementMap]
+  final lazy val feDisplacementMap = "feDisplacementMap".tag[*.FEDisplacementMap]
   /**
    * This filter primitive define a distant light source that can be used
    * within a lighting filter primitive: fediffuselighting or
@@ -181,49 +184,49 @@ trait SvgTags {
    *
    * MDN
    */
-  final lazy val fedistantlighting = "fedistantlighting".tag[*.FEDistantLight]
+  final lazy val feDistantLight = "feDistantLight".tag[*.FEDistantLight]
   /**
    * The filter fills the filter subregion with the color and opacity defined by
    * flood-color and flood-opacity.
    *
    * MDN
    */
-  final lazy val feflood = "feflood".tag[*.FEFlood]
+  final lazy val feFlood = "feFlood".tag[*.FEFlood]
   /**
    * This filter primitive defines the transfer function for the alpha component
    * of the input graphic of its parent fecomponenttransfer element.
    *
    * MDN
    */
-  final lazy val fefunca = "fefunca".tag[*.FEFuncA]
+  final lazy val feFuncA = "feFuncA".tag[*.FEFuncA]
   /**
    * This filter primitive defines the transfer function for the blue component
    * of the input graphic of its parent fecomponenttransfer element.
    *
    * MDN
    */
-  final lazy val fefuncb = "fefuncb".tag[*.FEFuncB]
+  final lazy val feFuncB = "feFuncB".tag[*.FEFuncB]
   /**
    * This filter primitive defines the transfer function for the green component
    * of the input graphic of its parent fecomponenttransfer element.
    *
    * MDN
    */
-  final lazy val fefuncg = "fefuncg".tag[*.FEFuncG]
+  final lazy val feFuncG = "feFuncG".tag[*.FEFuncG]
   /**
    * This filter primitive defines the transfer function for the red component
    * of the input graphic of its parent fecomponenttransfer element.
    *
    * MDN
    */
-  final lazy val fefuncr = "fefuncr".tag[*.FEFuncR]
+  final lazy val feFuncR = "feFuncR".tag[*.FEFuncR]
   /**
    * The filter blurs the input image by the amount specified in stdDeviation,
    * which defines the bell-curve.
    *
    * MDN
    */
-  final lazy val fegaussianblur = "fegaussianblur".tag[*.FEGaussianBlur]
+  final lazy val feFaussianBlur = "feFaussianBlur".tag[*.FEGaussianBlur]
 
   /**
    * The feImage filter fetches image data from an external source and provides
@@ -232,7 +235,7 @@ trait SvgTags {
    *
    * MDN
    */
-  final lazy val feimage = "feimage".tag[*.FEImage]
+  final lazy val feImage = "feImage".tag[*.FEImage]
 
   /**
    * The feMerge filter allows filter effects to be applied concurrently
@@ -242,7 +245,7 @@ trait SvgTags {
    *
    * MDN
    */
-  final lazy val femerge = "femerge".tag[*.FEMerge]
+  final lazy val feMerge = "feMerge".tag[*.FEMerge]
 
   /**
    * The feMergeNode takes the result of another filter to be processed by its
@@ -250,22 +253,22 @@ trait SvgTags {
    *
    * MDN
    */
-  final lazy val femergenode = "femergenode".tag[*.FEMergeNode]
+  final lazy val feMergeNode = "feMergeNode".tag[*.FEMergeNode]
   /**
    * This filter is used to erode or dilate the input image. It's usefulness
    * lies especially in fattening or thinning effects.
    *
    * MDN
    */
-  final lazy val femorphology = "femorphology".tag[*.FEMorphology]
+  final lazy val feMorphology = "feMorphology".tag[*.FEMorphology]
   /**
    * The input image as a whole is offset by the values specified in the dx
    * and dy attributes. It's used in creating drop-shadows.
    *
    * MDN
    */
-  final lazy val feoffset = "feoffset".tag[*.FEOffset]
-  final lazy val fepointlight = "fepointlight".tag[*.FEPointLight]
+  final lazy val feOffset = "feOffset".tag[*.FEOffset]
+  final lazy val fePointLight = "fePointLight".tag[*.FEPointLight]
   /**
    * This filter primitive lights a source graphic using the alpha channel as a
    * bump map. The resulting image is an RGBA image based on the light color.
@@ -277,18 +280,18 @@ trait SvgTags {
    *
    * MDN
    */
-  final lazy val fespecularlighting = "fespecularlighting".tag[*.FESpecularLighting]
+  final lazy val feSpecularLighting = "feSpecularLighting".tag[*.FESpecularLighting]
   /**
    *
    */
-  final lazy val fespotlight = "fespotlight".tag[*.FESpotLight]
+  final lazy val feSpotLight = "feSpotLight".tag[*.FESpotLight]
   /**
    * An input image is tiled and the result used to fill a target. The effect
    * is similar to the one of a pattern.
    *
    * MDN
    */
-  final lazy val fetile = "fetile".tag[*.FETile]
+  final lazy val feTile = "feTile".tag[*.FETile]
   /**
    * This filter primitive creates an image using the Perlin turbulence
    * function. It allows the synthesis of artificial textures like clouds or
@@ -296,7 +299,7 @@ trait SvgTags {
    *
    * MDN
    */
-  final lazy val feturbulance = "feturbulance".tag[*.FETurbulence]
+  final lazy val feTurbulance = "feTurbulance".tag[*.FETurbulence]
   /**
    * The filter element serves as container for atomic filter operations. It is
    * never rendered directly. A filter is referenced by using the filter
@@ -304,7 +307,7 @@ trait SvgTags {
    *
    * MDN
    */
-  final lazy val filterTag = "filter".tag[*.Filter]
+  final lazy val filter = "filter".tag[*.Filter]
   /**
    * The font element defines a font to be used for text layout.
    *
@@ -355,7 +358,7 @@ trait SvgTags {
    *
    * MDN
    */
-  final lazy val foreignobject = "foreignObject".tag[*.Element]
+  final lazy val foreignObject = "foreignObject".tag[*.Element]
   /**
    * The g element is a container used to group objects. Transformations applied
    * to the g element are performed on all of its child elements. Attributes
@@ -377,7 +380,7 @@ trait SvgTags {
    *
    * MDN
    */
-  final lazy val glyphref = "glyphref".tag[*.Element]
+  final lazy val glyphRef = "glyphRef".tag[*.Element]
   /**
    * The horizontal distance between two glyphs can be fine-tweaked with an
    * hkern Element. This process is known as Kerning.
@@ -405,7 +408,7 @@ trait SvgTags {
    *
    * MDN
    */
-  final lazy val lineargradient = "lineargradient".tag[*.LinearGradient]
+  final lazy val linearGradient = "linearGradient".tag[*.LinearGradient]
   /**
    * The marker element defines the graphics that is to be used for drawing
    * arrowheads or polymarkers on a given path, line, polyline or
@@ -422,7 +425,7 @@ trait SvgTags {
    *
    * MDN
    */
-  final lazy val maskTag = "mask".tag[*.Mask]
+  final lazy val mask = "mask".tag[*.Mask]
   /**
    * Metadata is structured data about data. Metadata which is included with SVG
    * content should be specified within metadata elements. The contents of the
@@ -483,7 +486,7 @@ trait SvgTags {
    *
    * MDN
    */
-  final lazy val radialgradient = "radialgradient".tag[*.RadialGradient]
+  final lazy val radialGradient = "radialGradient".tag[*.RadialGradient]
   /**
    * The rect element is an SVG basic shape, used to create rectangles based on
    * the position of a corner and their width and height. It may also be used to
@@ -492,6 +495,16 @@ trait SvgTags {
    * MDN
    */
   final lazy val rect = "rect".tag[*.RectElement]
+  /**
+   * A SVG script element is equivalent to the script element in HTML and thus is
+   * the place for scripts (e.g., ECMAScript).
+   *
+   * Any functions defined within any script element have a global scope across* the
+   * entire current document.
+   *
+   * MDN
+   */
+  final lazy val script = "script".tag[*.Script]
   /**
    * The set element provides a simple means of just setting the value of an
    * attribute for a specified duration. It supports all attribute types,
@@ -560,7 +573,24 @@ trait SvgTags {
    *
    * MDN
    */
-  final lazy val textpath = "textpath".tag[*.TextPath]
+  final lazy val textPath = "textPath".tag[*.TextPath]
+  /**
+   * Each container element or graphics element in an SVG drawing can supply
+   * a title description string where the description is text-only. When the
+   * current SVG document fragment is rendered as SVG on visual media, title
+   * element is not rendered as part of the graphics. However, some user agents
+   * may, for example, display the title element as a tooltip. Alternate
+   * presentations are possible, both visual and aural, which display the title
+   * element but do not display path elements or other graphics elements. The
+   * title element generally improve accessibility of SVG documents
+   *
+   * Generally title element should be the first child element of its parent.
+   * Note that those implementations that do use title to display a tooltip often
+   * will only do so if the title is indeed the first child element of its parent.
+   *
+   * MDN
+   */
+  final lazy val title = "textPath".tag[*.Title]
   /**
    * The textual content for a text can be either character data directly
    * embedded within the text element or the character data content of a

--- a/core/src/main/scala/japgolly/scalajs/react/vdom/SvgTags.scala
+++ b/core/src/main/scala/japgolly/scalajs/react/vdom/SvgTags.scala
@@ -355,7 +355,7 @@ trait SvgTags {
    *
    * MDN
    */
-  final lazy val foreignobject = "foreignobject".tag[*.Element]
+  final lazy val foreignobject = "foreignObject".tag[*.Element]
   /**
    * The g element is a container used to group objects. Transformations applied
    * to the g element are performed on all of its child elements. Attributes

--- a/doc/changelog/0.11.2.md
+++ b/doc/changelog/0.11.2.md
@@ -4,7 +4,6 @@
   * Tag names now use camelCase
   * Fix `fedistantlighting` vs. `feDistantLight` inconsistency
   * Add `script` and `title` tags
-  * Remove `Tag` suffix from `cursorTag`, `filterTag`, and `maskTag`
 
 * `RouterConfig` gained convenience methods for setting the page title when route changes.
   * `.setTitle(Page => String)`

--- a/doc/changelog/0.11.2.md
+++ b/doc/changelog/0.11.2.md
@@ -1,5 +1,11 @@
 ## 0.11.2 (unreleased)
 
+* Bring `SvgTags` in line with [MDN SVG element reference](https://developer.mozilla.org/en-US/docs/Web/SVG/Element).
+  * Tag names now use camelCase
+  * Fix `fedistantlighting` vs. `feDistantLight` inconsistency
+  * Add `script` and `title` tags
+  * Remove `Tag` suffix from `cursorTag`, `filterTag`, and `maskTag`
+
 * `RouterConfig` gained convenience methods for setting the page title when route changes.
   * `.setTitle(Page => String)`
   * `.setTitleOption(Page => Option[String])`


### PR DESCRIPTION
First and foremost: Thank you very much for such an awesome library!

Now concerning the PR:

I would like to include HTML inside an SVG via `foreignObject`. Apparently, SVG tags are case-sensitive ([see my SO post for details](http://stackoverflow.com/questions/39504988/react-svg-html-inside-foreignobject-not-rendered)).

Obviously, the PR is more a selfish patch than a proper fix – probably many other SVG tags have the same problem. How should we approach this?