### PR TITLE
Support for namespaces in JsComponent name.

### DIFF
--- a/neo/src/test/resources/component-es3.js
+++ b/neo/src/test/resources/component-es3.js
@@ -22,3 +22,14 @@ const ES3_S = React.createClass({
   }
 });
 
+const TestNS = {
+    SubNS: {
+        MyNestedCmp: React.createClass({
+         displayName: "MyNestedComponent",
+
+         render: function render() {
+           return React.createElement("div", null, "I am nested");
+         }
+       })
+    }
+}

--- a/neo/src/test/scala/japgolly/scalajs/react/JsComponentTest.scala
+++ b/neo/src/test/scala/japgolly/scalajs/react/JsComponentTest.scala
@@ -1,5 +1,8 @@
 package japgolly.scalajs.react
 
+import japgolly.scalajs.react.CtorType.Void
+import japgolly.scalajs.react.JsComponent.Basic
+
 import scalajs.js
 import utest._
 import japgolly.scalajs.react.test.ReactTestUtils
@@ -10,6 +13,34 @@ import vdom.ImplicitsFromRaw._
 abstract class JsComponentTest extends TestSuite {
   final val H1: raw.ReactElement =
     raw.React.createElement("h1", null, "Huge")
+}
+
+object JsComponentNSTest extends  JsComponentTest {
+
+  override def tests = TestSuite {
+
+    def tryResolve(name: String) : Boolean = {
+      try {
+        JsComponent.byName[Null, ChildrenArg.None, Null](name).raw
+        true
+      } catch {
+        case ex: IllegalArgumentException => false
+      }
+    }
+
+    'resolve {
+      'defined {
+        assertEq(tryResolve("TestNS.SubNS.MyNestedCmp"), true)
+      }
+
+      'undefined {
+        assertEq(tryResolve(""), false)
+        assertEq(tryResolve("TestNS"), false)
+        assertEq(tryResolve("TestNS.MissingNS"), false)
+        assertEq(tryResolve("TestNS.SubNS.MyMissingCmp"), false)
+      }
+    }
+  }
 }
 
 object JsComponentPTest extends JsComponentTest {


### PR DESCRIPTION
Small change for neo. Supports using a js React component in a different namespace than global.
Also throws a more descriptive error message when the component constructor does not exist.

For example: 
```
JsComponent.byName[Props, ChildrenArg.Varargs, Props]("ReactLeaflet.Map")
```