### PR TITLE
Upgrade to Scala.js 0.6.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,5 +50,5 @@ Includes a router, testing utils, performance utils, more.
 ##### Requirements:
 * React 15+
 * Scala 2.11.n
-* Scala.JS 0.6.8+
+* Scala.JS 0.6.13+
 

--- a/doc/changelog/0.11.3.md
+++ b/doc/changelog/0.11.3.md
@@ -1,0 +1,1 @@
+* Upgrade Scala.JS to v0.6.13.

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.12")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.13")
 
 libraryDependencies += "org.scala-js" %% "scalajs-env-selenium" % "0.1.2"
 


### PR DESCRIPTION
I wasn’t able to run the tests because I don’t have phantomjs but everything compiles fine without any warning.
