### PR TITLE
Migrate to scalajs-bundler

### DIFF
--- a/core/src/main/scala/japgolly/scalajs/react/Addons.scala
+++ b/core/src/main/scala/japgolly/scalajs/react/Addons.scala
@@ -1,18 +1,13 @@
 package japgolly.scalajs.react
 
 import scala.scalajs.js
-import js.annotation.JSName
+import js.annotation.JSImport
 
 object Addons {
 
-  object ReactCssTransitionGroup {
-    /** Items in the CSSTransitionGroup need this attribute for animation to work properly. */
-    @inline final def key = vdom.Attrs.key
-
-    private val factory =
-      React.createFactory(
-        React.addons.CSSTransitionGroup.asInstanceOf[JsComponentType[js.Any, js.Any, TopNode]])
-  }
+  @JSImport("react-addons-css-transition-group", JSImport.Namespace)
+  @js.native
+  object CSSTransitionGroup extends JsComponentType[js.Any, js.Any, TopNode]
 
   /**
     * [[ReactCssTransitionGroup]] is based on `ReactTransitionGroup` and is an easy way to perform CSS transitions and
@@ -57,7 +52,7 @@ object Addons {
       * single item. This is how React will determine which children have entered, left, or stayed.
       */
     def apply(children: ReactNode*): ReactComponentU_ =
-      ReactCssTransitionGroup.factory(toJs, children.toJsArray).asInstanceOf[ReactComponentU_]
+      React.createFactory(CSSTransitionGroup)(toJs, children.toJsArray).asInstanceOf[ReactComponentU_]
   }
 
   // ===================================================================================================================
@@ -67,8 +62,8 @@ object Addons {
    *
    * @see https://facebook.github.io/react/docs/perf.html
    */
+  @JSImport("react-addons-perf", JSImport.Namespace)
   @js.native
-  @JSName("React.addons.Perf")
   object Perf extends js.Object {
 
     // Opaque pending:

--- a/core/src/main/scala/japgolly/scalajs/react/React.scala
+++ b/core/src/main/scala/japgolly/scalajs/react/React.scala
@@ -1,8 +1,10 @@
 package japgolly.scalajs.react
 
 import scala.scalajs.js
-import js.{Dynamic, UndefOr, Object, Any => JAny}
+import js.{Dynamic, Object, UndefOr, Any => JAny}
+import scala.scalajs.js.annotation.JSImport
 
+@JSImport("react", JSImport.Namespace)
 @js.native
 object React extends React
 
@@ -58,8 +60,6 @@ trait React extends Object {
    * when not using JSX. For example, React.DOM.div(null, 'Hello World!')
    */
   def DOM: Dynamic = js.native
-
-  def addons: Dynamic = js.native
 
   /** React.Children provides utilities for dealing with the this.props.children opaque data structure. */
   def Children: ReactChildren = js.native

--- a/core/src/main/scala/japgolly/scalajs/react/ReactDOM.scala
+++ b/core/src/main/scala/japgolly/scalajs/react/ReactDOM.scala
@@ -1,9 +1,12 @@
 package japgolly.scalajs.react
 
 import org.scalajs.dom
-import scala.scalajs.js
-import js.{ThisFunction, ThisFunction0, Object}
 
+import scala.scalajs.js
+import js.{Object, ThisFunction, ThisFunction0}
+import scala.scalajs.js.annotation.JSImport
+
+@JSImport("react-dom", JSImport.Namespace)
 @js.native
 object ReactDOM extends ReactDOM
 
@@ -118,6 +121,7 @@ trait ReactDOM extends Object {
   def findDOMNode[N <: TopNode](component: CompScope.Mounted[N]): N = js.native
 }
 
+@JSImport("react-dom/server", JSImport.Namespace)
 @js.native
 object ReactDOMServer extends ReactDOMServer
 

--- a/doc/USAGE.md
+++ b/doc/USAGE.md
@@ -20,33 +20,13 @@ It is expected that you know how React itself works.
 Setup
 =====
 
-1. Add [Scala.js](http://www.scala-js.org) to your project.
+1. Add [scalajs-bundler](https://scalacenter.github.io/scalajs-bundler/getting-started.html) to your project.
 
 2. Add *scalajs-react* to SBT:
 
   ```scala
   // core = essentials only. No bells or whistles.
   libraryDependencies += "com.github.japgolly.scalajs-react" %%% "core" % "0.11.3"
-
-  // React JS itself (Note the filenames, adjust as needed, eg. to remove addons.)
-  jsDependencies ++= Seq(
-
-    "org.webjars.bower" % "react" % "15.3.2"
-      /        "react-with-addons.js"
-      minified "react-with-addons.min.js"
-      commonJSName "React",
-
-    "org.webjars.bower" % "react" % "15.3.2"
-      /         "react-dom.js"
-      minified  "react-dom.min.js"
-      dependsOn "react-with-addons.js"
-      commonJSName "ReactDOM",
-
-    "org.webjars.bower" % "react" % "15.3.2"
-      /         "react-dom-server.js"
-      minified  "react-dom-server.min.js"
-      dependsOn "react-dom.js"
-      commonJSName "ReactDOMServer")
   ```
 
 Creating Virtual-DOM

--- a/doc/USAGE.md
+++ b/doc/USAGE.md
@@ -29,6 +29,17 @@ Setup
   libraryDependencies += "com.github.japgolly.scalajs-react" %%% "core" % "0.11.3"
   ```
 
+3. Add dependencies to React.js (adjust as needed, eg. to remove addons):
+
+  ~~~ scala
+  npmDependencies in Compile ++= Seq(
+    "react" -> "15.3.2",
+    "react-dom" -> "15.3.2",
+    "react-addons-perf" -> "15.3.2", // Optional
+    "react-addons-css-transition-group" -> "15.3.3" // Optional
+  )
+  ~~~
+
 Creating Virtual-DOM
 ====================
 

--- a/gh-pages/dev.html
+++ b/gh-pages/dev.html
@@ -6,32 +6,11 @@
     <link rel="stylesheet" href="res/bootstrap.css">
     <link rel="stylesheet" href="res/app.css">
     <link rel="stylesheet" href="res/default.css">
-    <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/react/15.0.1/react-with-addons.js"></script>
-    <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/react/15.0.1/react-dom.js"></script>
     <script type="text/javascript" src="res/highlight.pack.js"></script>
 </head>
 <body>
 
-<script>
-    function jsonp(url, callback) {
-        var callbackName = 'jsonp_callback_' + Math.round(100000 * Math.random());
-        window[callbackName] = function(data) {
-            delete window[callbackName];
-//            document.body.removeChild(script);
-            callback(data);
-        };
+<script type="text/javascript" src="target/scala-2.11/gh-pages-fastopt-bundle.js"></script>
 
-        var script = document.createElement('script');
-        script.src = url + (url.indexOf('?') >= 0 ? '&' : '?') + 'callback=' + callbackName;
-        document.body.appendChild(script);
-    }
-</script>
-
-<script type="text/javascript" src="target/scala-2.11/gh-pages-fastopt.js"></script>
-
-<script type="text/javascript">
-  ((typeof global === "object" && global &&
-         global["Object"] === Object) ? global : this)["ghpages"]["GhPages"]().main();
-</script>
 </body>
 </html>

--- a/gh-pages/index.html
+++ b/gh-pages/index.html
@@ -6,32 +6,11 @@
     <link rel="stylesheet" href="res/bootstrap.css">
     <link rel="stylesheet" href="res/app.css">
     <link rel="stylesheet" href="res/default.css">
-    <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/react/15.0.1/react-with-addons.min.js"></script>
-    <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/react/15.0.1/react-dom.min.js"></script>
     <script type="text/javascript" src="res/highlight.pack.js"></script>
 </head>
 <body>
 
-<script>
-    function jsonp(url, callback) {
-        var callbackName = 'jsonp_callback_' + Math.round(100000 * Math.random());
-        window[callbackName] = function(data) {
-            delete window[callbackName];
-//            document.body.removeChild(script);
-            callback(data);
-        };
-
-        var script = document.createElement('script');
-        script.src = url + (url.indexOf('?') >= 0 ? '&' : '?') + 'callback=' + callbackName;
-        document.body.appendChild(script);
-    }
-</script>
-
 <script type="text/javascript" src="res/ghpages.js"></script>
 
-<script type="text/javascript">
-  ((typeof global === "object" && global &&
-         global["Object"] === Object) ? global : this)["ghpages"]["GhPages"]().main();
-</script>
 </body>
 </html>

--- a/gh-pages/src/main/resources/jsonp.js
+++ b/gh-pages/src/main/resources/jsonp.js
@@ -1,0 +1,12 @@
+module.exports = function jsonp(url, callback) {
+  var callbackName = 'jsonp_callback_' + Math.round(100000 * Math.random());
+  window[callbackName] = function(data) {
+    delete window[callbackName];
+//            document.body.removeChild(script);
+    callback(data);
+  };
+
+  var script = document.createElement('script');
+  script.src = url + (url.indexOf('?') >= 0 ? '&' : '?') + 'callback=' + callbackName;
+  document.body.appendChild(script);
+};

--- a/gh-pages/src/main/scala/ghpages/Jsonp.scala
+++ b/gh-pages/src/main/scala/ghpages/Jsonp.scala
@@ -1,0 +1,10 @@
+package ghpages
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSImport
+
+@JSImport("./jsonp.js", JSImport.Namespace)
+@js.native
+object Jsonp extends js.Function2[String, js.Function1[js.Dynamic, Unit], Unit] {
+  def apply(url: String, callback: js.Function1[js.Dynamic, Unit]): Unit = js.native
+}

--- a/gh-pages/src/main/scala/ghpages/examples/PictureAppExample.scala
+++ b/gh-pages/src/main/scala/ghpages/examples/PictureAppExample.scala
@@ -1,7 +1,9 @@
 package ghpages.examples
 
-import ghpages.GhPagesMacros
-import japgolly.scalajs.react._, vdom.all._
+import ghpages.{GhPagesMacros, Jsonp}
+import japgolly.scalajs.react._
+import vdom.all._
+
 import scala.scalajs.js
 import ghpages.examples.util.SideBySide
 
@@ -196,8 +198,8 @@ object PictureAppExample {
       import scalajs.js.Dynamic.{global => g}
       def isDefined(g: js.Dynamic): Boolean =
         g.asInstanceOf[js.UndefOr[AnyRef]].isDefined
-      val url = "https://api.instagram.com/v1/media/popular?client_id=642176ece1e7445e99244cec26f4de1f&callback=?"
-      g.jsonp(url, (result: js.Dynamic) => {
+      val url = "https://api.instagram.com/v1/media/popular?client_id=642176ece1e7445e99244cec26f4de1f"
+      Jsonp(url, (result: js.Dynamic) => {
         if (isDefined(result) && isDefined(result.data)) {
           val data = result.data.asInstanceOf[js.Array[js.Dynamic]]
           val pics = data.toList.map(item => Picture(item.id.toString, item.link.toString, item.images.low_resolution.url.toString, if (item.caption != null) item.caption.text.toString else ""))

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -83,10 +83,20 @@ object ScalajsReact {
     )
 
   def utestSettings: PE =
+    _.configure(useReactJs(Test))
+      .settings(
+        libraryDependencies += "com.lihaoyi" %%% "utest" % Ver.MTest % Test,
+        testFrameworks      += new TestFramework("utest.runner.Framework"),
+        requiresDOM         := true)
+
+  def useReactJs(scope: Configuration = Compile): PE =
     _.settings(
-      libraryDependencies += "com.lihaoyi" %%% "utest" % Ver.MTest % Test,
-      testFrameworks      += new TestFramework("utest.runner.Framework"),
-      requiresDOM         := true
+      npmDependencies in scope ++= Seq(
+        "react" -> Ver.ReactJs,
+        "react-dom" -> Ver.ReactJs,
+        "react-addons-perf" -> Ver.ReactJs,
+        "react-addons-css-transition-group" -> Ver.ReactJs
+      )
     )
 
   def addCommandAliases(m: (String, String)*) = {
@@ -135,14 +145,7 @@ object ScalajsReact {
     .settings(
       name := "core",
       libraryDependencies ++= Seq(
-        "org.scala-js" %%% "scalajs-dom" % Ver.ScalaJsDom),
-      npmDependencies in Compile ++= Seq(
-        "react" -> Ver.ReactJs,
-        "react-dom" -> Ver.ReactJs,
-        "react-addons-perf" -> Ver.ReactJs,
-        "react-addons-css-transition-group" -> Ver.ReactJs
-      )
-    )
+        "org.scala-js" %%% "scalajs-dom" % Ver.ScalaJsDom))
 
   lazy val extra = project
     .configure(commonSettings, publicationSettings, definesMacros, hasNoTests)
@@ -196,7 +199,7 @@ object ScalajsReact {
 
   lazy val ghpages = Project("gh-pages", file("gh-pages"))
     .dependsOn(core, extra, monocle, ghpagesMacros)
-    .configure(commonSettings, preventPublication, hasNoTests)
+    .configure(commonSettings, useReactJs(), preventPublication, hasNoTests)
     .settings(
       libraryDependencies += monocleLib("macro"),
       addCompilerPlugin(macroParadisePlugin),

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -159,10 +159,12 @@ object ScalajsReact {
         "com.github.japgolly.nyaya" %%% "nyaya-gen"  % Ver.Nyaya % "test",
         "com.github.japgolly.nyaya" %%% "nyaya-test" % Ver.Nyaya % "test",
         monocleLib("macro") % "test"),
+      npmDependencies in Compile ++= Seq(
+        "react-addons-test-utils" -> Ver.ReactJs
+      ),
       npmDependencies in Test ++= Seq(
         "react-dom" -> Ver.ReactJs, // for JS component Type Test.
-        "sizzle" -> Ver.SizzleJs,
-        "react-addons-test-utils" -> Ver.ReactJs
+        "sizzle" -> Ver.SizzleJs
       ),
       addCompilerPlugin(macroParadisePlugin),
       scalacOptions in Test += "-language:reflectiveCalls")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,7 @@
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.13")
 
+addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.3.0")
+
 libraryDependencies += "org.scala-js" %% "scalajs-env-selenium" % "0.1.2"
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.13")
 
-addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.3.0")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.3.1")
 
 libraryDependencies += "org.scala-js" %% "scalajs-env-selenium" % "0.1.2"
 

--- a/test/src/main/scala/japgolly/scalajs/react/test/ReactTestUtils.scala
+++ b/test/src/main/scala/japgolly/scalajs/react/test/ReactTestUtils.scala
@@ -1,13 +1,13 @@
 package japgolly.scalajs.react.test
 
 import scala.scalajs.js
-import scala.scalajs.js.{Function1 => JFn1, Object, Array, UndefOr, undefined, Dynamic, native}
-import scala.scalajs.js.annotation.JSName
+import scala.scalajs.js.{Array, Dynamic, Object, UndefOr, native, undefined, Function1 => JFn1}
+import scala.scalajs.js.annotation.JSImport
 import japgolly.scalajs.react._
 
 /** https://facebook.github.io/react/docs/test-utils.html */
 @js.native
-@JSName("React.addons.TestUtils")
+@JSImport("react-addons-test-utils", JSImport.Namespace)
 object ReactTestUtils extends ReactTestUtils
 
 @js.native

--- a/test/src/test/resources/sampleReactComponent.js
+++ b/test/src/test/resources/sampleReactComponent.js
@@ -1,4 +1,6 @@
-var SampleReactComponent = React.createClass({
+var React = require('react');
+
+module.exports = React.createClass({
   getInitialState: function() {
     return {num:0,num2:0};
   },

--- a/test/src/test/scala/Sizzle.scala
+++ b/test/src/test/scala/Sizzle.scala
@@ -1,7 +1,9 @@
 package sizzle
 
 import scala.scalajs.js
+import scala.scalajs.js.annotation.JSImport
 
+@JSImport("sizzle", JSImport.Namespace)
 @js.native
 object Sizzle extends js.Object {
 

--- a/test/src/test/scala/japgolly/scalajs/react/JsComponentTest.scala
+++ b/test/src/test/scala/japgolly/scalajs/react/JsComponentTest.scala
@@ -1,11 +1,11 @@
 package japgolly.scalajs.react
 
 import scala.scalajs.js
-import scala.scalajs.js.annotation.JSName
+import scala.scalajs.js.annotation.JSImport
 import org.scalajs.dom.raw.HTMLElement
 import utest._
 import japgolly.scalajs.react._
-import japgolly.scalajs.react.test.{Simulation, ReactTestUtils}
+import japgolly.scalajs.react.test.{ReactTestUtils, Simulation}
 import japgolly.scalajs.react.vdom.prefix_<^._
 
 object JsComponentTest extends TestSuite {
@@ -102,7 +102,7 @@ object SampleReactComponentState {
   }
 }
 
-@JSName("SampleReactComponent")
+@JSImport("./sampleReactComponent.js", JSImport.Namespace)
 @js.native
 object SampleReactComponent extends JsComponentType[SampleReactComponentProperty, SampleReactComponentState, HTMLElement]
 

--- a/test/src/test/scala/japgolly/scalajs/react/extra/router/Router2Test.scala
+++ b/test/src/test/scala/japgolly/scalajs/react/extra/router/Router2Test.scala
@@ -136,7 +136,7 @@ object Router2Test extends TestSuite {
 
   override val tests = TestSuite {
     import MyPage2._
-    implicit val base = BaseUrl("file:///router2Demo/")
+    implicit val base = BaseUrl("http://localhost/")
     val (router, lgc) = Router.componentAndLogic(base, config)
     val ctl = lgc.ctl
 

--- a/test/src/test/scala/japgolly/scalajs/react/extra/router/RouterTest.scala
+++ b/test/src/test/scala/japgolly/scalajs/react/extra/router/RouterTest.scala
@@ -72,7 +72,7 @@ object RouterTest extends TestSuite {
 
     'sim {
       import MyPage.{Root, Hello, Greet, Person}
-      val base = BaseUrl("file:///routerDemo")
+      val base = BaseUrl("http://localhost/")
       val router = Router(base, MyPage.config.logToConsole)
       val c = ReactTestUtils.renderIntoDocument(router())
       def node = ReactDOM findDOMNode c


### PR DESCRIPTION
I wanted to play with scalajs-bundler in the context of a large Scala.js facade, so I naturally went to scalajs-react, which is one of the most used facades.

It turns out that it works well with scalajs-bundler. In my opinion the builds of projects that use scalajs-react become simpler with this PR. I will highlight some parts of the PR by commenting in the diff.

A drawback of scalajs-bundler is that a concrete facade can not be compatible with both `npmDependencies` and `jsDependencies`, so existing users will be forced to move to scalajs-bundler. A solution to this problem could be to isolate the facade interfaces into separate, small sbt sub-projects, and then have two different concrete facades (one that would work with `npmDependencies` and the other with `jsDependencies`).