### PR TITLE
Adding a link to a simple routing example.

### DIFF
--- a/doc/ROUTER.md
+++ b/doc/ROUTER.md
@@ -655,3 +655,5 @@ uses this router and demonstrates a number of features.
 There are also unit tests available in the
 [japgolly.scalajs.react.extra.router](../test/src/test/scala/japgolly/scalajs/react/extra/router)
 package.
+
+[This] (https://github.com/chandu0101/scalajs-react-template) simple example [demonstrates](http://chandu0101.github.io/scalajs-react-template/) routing as well.


### PR DESCRIPTION
Having this link there would have saved me a few hours of searching.