### PR TITLE
Make Callback.when lazy

### DIFF
--- a/core/src/main/scala/japgolly/scalajs/react/Callback.scala
+++ b/core/src/main/scala/japgolly/scalajs/react/Callback.scala
@@ -91,7 +91,7 @@ object Callback {
    * @param cond The condition required to be `true` for the callback to execute.
    */
   def when(cond: Boolean)(c: => Callback): Callback =
-    if (cond) c else Callback.empty
+    Callback.lazily(if (cond) c else Callback.empty)
 
   /**
    * Convenience for applying a condition to a callback, and returning `Callback.empty` when the condition is already

--- a/core/src/main/scala/japgolly/scalajs/react/Callback.scala
+++ b/core/src/main/scala/japgolly/scalajs/react/Callback.scala
@@ -90,8 +90,8 @@ object Callback {
    *
    * @param cond The condition required to be `true` for the callback to execute.
    */
-  def when(cond: Boolean)(c: => Callback): Callback =
-    Callback.lazily(if (cond) c else Callback.empty)
+  def when(cond: => Boolean)(c: => Callback): Callback =
+    if (cond) c else Callback.empty
 
   /**
    * Convenience for applying a condition to a callback, and returning `Callback.empty` when the condition is already


### PR DESCRIPTION
hey,
Callback.when should be evaluated lazily in my opinion, one example:

```scala
DifferentComponent(callback = Callback.when(dom.confirm("Really?"))(doSomething))
```