### PR TITLE
v0.11.4 with scala.js 0.6.16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: scala
 sudo: false
 
 scala:
-  - 2.11.8
-  - 2.12.0
+  - 2.11.11
+  - 2.12.2
 
 jdk:
   - oraclejdk8

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Includes a router, testing utils, performance utils, more.
   - [Performance Management](doc/PERFORMANCE.md).
   - [Smaller stuff](doc/EXTRA.md).
 - [Testing](doc/TESTING.md).
-- [Changelogs](doc/changelog) — [Latest](doc/changelog/0.11.3.md).
+- [Changelogs](doc/changelog) — [Latest](doc/changelog/0.11.4.md).
 
 
 ##### External Resources
@@ -50,5 +50,5 @@ Includes a router, testing utils, performance utils, more.
 ##### Requirements:
 * React 15+
 * Scala 2.11+
-* Scala.JS 0.6.13+
+* Scala.JS 0.6.15+
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-version in ThisBuild := "0.11.3"
+version in ThisBuild := "0.11.4"
 
 val root          = ScalajsReact.root
 val core          = ScalajsReact.core

--- a/doc/EXTRA.md
+++ b/doc/EXTRA.md
@@ -5,7 +5,7 @@ This describes the smaller utilities in the `extra` module.
 Find links to the larger utilities from the [main README](../README.md).
 
 ```scala
-libraryDependencies += "com.github.japgolly.scalajs-react" %%% "extra" % "0.11.3"
+libraryDependencies += "com.github.japgolly.scalajs-react" %%% "extra" % "0.11.4"
 ```
 
 #### Contents

--- a/doc/FP.md
+++ b/doc/FP.md
@@ -22,7 +22,7 @@ Scalaz
 ======
 
 ```scala
-libraryDependencies += "com.github.japgolly.scalajs-react" %%% "ext-scalaz72" % "0.11.3"
+libraryDependencies += "com.github.japgolly.scalajs-react" %%% "ext-scalaz72" % "0.11.4"
 ```
 
 Included is a Scalaz module that facilitates a more functional and pure approach to React integration.
@@ -39,7 +39,7 @@ Monocle
 =======
 
 ```scala
-libraryDependencies += "com.github.japgolly.scalajs-react" %%% "ext-monocle" % "0.11.3"
+libraryDependencies += "com.github.japgolly.scalajs-react" %%% "ext-monocle" % "0.11.4"
 ```
 
 A module with a extensions for [Monocle](https://github.com/julien-truffaut/Monocle) also exists under `ext-monocle`.

--- a/doc/PERFORMANCE.md
+++ b/doc/PERFORMANCE.md
@@ -10,7 +10,7 @@ These utilities help you avoid work in two ways.
 2. By allowing you to cache your own arbitrary data, and build on it in a way such that derivative data is also cached effeciently.
 
 ```scala
-libraryDependencies += "com.github.japgolly.scalajs-react" %%% "extra" % "0.11.3"
+libraryDependencies += "com.github.japgolly.scalajs-react" %%% "extra" % "0.11.4"
 ```
 
 ### Contents

--- a/doc/ROUTER.md
+++ b/doc/ROUTER.md
@@ -6,7 +6,7 @@ Included is a router (in the orbit of Single-Page Applications) that is written 
 The package is `japgolly.scalajs.react.extra.router`.
 
 ```scala
-libraryDependencies += "com.github.japgolly.scalajs-react" %%% "extra" % "0.11.3"
+libraryDependencies += "com.github.japgolly.scalajs-react" %%% "extra" % "0.11.4"
 ```
 
 ## Contents

--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -28,7 +28,7 @@ Setup
 
     ```scala
     // scalajs-react test module
-    libraryDependencies += "com.github.japgolly.scalajs-react" %%% "test" % "0.11.3" % "test"
+    libraryDependencies += "com.github.japgolly.scalajs-react" %%% "test" % "0.11.4" % "test"
 
     // React JS itself.
     // NOTE: Requires react-with-addons.js instead of just react.js

--- a/doc/USAGE.md
+++ b/doc/USAGE.md
@@ -26,7 +26,7 @@ Setup
 
   ```scala
   // core = essentials only. No bells or whistles.
-  libraryDependencies += "com.github.japgolly.scalajs-react" %%% "core" % "0.11.3"
+  libraryDependencies += "com.github.japgolly.scalajs-react" %%% "core" % "0.11.4"
 
   // React JS itself (Note the filenames, adjust as needed, eg. to remove addons.)
   jsDependencies ++= Seq(

--- a/doc/changelog/0.11.4.md
+++ b/doc/changelog/0.11.4.md
@@ -1,4 +1,4 @@
 ## 0.11.4
 
-* Upgrade Scala.JS to v0.6.15.
+* Upgrade Scala.JS to v0.6.16.
 * Upgrade Scala 2.11 to 2.11.11 and 2.12 to 2.12.2

--- a/doc/changelog/0.11.4.md
+++ b/doc/changelog/0.11.4.md
@@ -1,0 +1,4 @@
+## 0.11.4
+
+* Upgrade Scala.JS to v0.6.15.
+* Upgrade Scala 2.11 to 2.11.11 and 2.12 to 2.12.2

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -8,8 +8,8 @@ import ScalaJSPlugin.autoImport._
 object ScalajsReact {
 
   object Ver {
-    val Scala211      = "2.11.8"
-    val Scala212      = "2.12.0"
+    val Scala211      = "2.11.11"
+    val Scala212      = "2.12.2"
     val ScalaJsDom    = "0.9.1"
     val ReactJs       = "15.3.2"
     val Monocle       = "1.3.2"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.13")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.15")
 
 libraryDependencies += "org.scala-js" %% "scalajs-env-selenium" % "0.1.2"
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.15")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.16")
 
 libraryDependencies += "org.scala-js" %% "scalajs-env-selenium" % "0.1.2"
 


### PR DESCRIPTION
This is the PR to address https://github.com/japgolly/scalajs-react/issues/354. Idea is to release a version of the scalajs-react 0.11.x series with the latest dependencies for scala.js (in this case its scala.js 0.6.16 which is the latest compatible version of Scalajs in the 0.6.x series)

Note that scala.js 0.6.16 is both backwards and forwards compatible with 0.6.15, hence why 0.6.15+ is the requirement, see https://www.scala-js.org/news/2017/04/29/announcing-scalajs-0.6.16/ for more info

@japgolly Does it make sense to bump JSDom as well? According to the release notes,

> It also adds support for jsdom v10.x (which contains breaking changes wrt. jsdom v9.x) and Scala 2.13.0-M1.

This is probably the main change for scala.js 0.6.16 vs 0.6.15