### PR TITLE
Integrate with Cats' IO

### DIFF
--- a/cats/src/main/scala/japgolly/scalajs/react/internal/CatsReactExt.scala
+++ b/cats/src/main/scala/japgolly/scalajs/react/internal/CatsReactExt.scala
@@ -6,6 +6,8 @@ import cats.effect.IO
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.extra._
 
+import scala.concurrent.Future
+
 /**
   * Created by alonsodomin on 13/03/2017.
   */

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -241,7 +241,9 @@ object ScalajsReact {
   lazy val cats = project
     .configure(commonSettings, publicationSettings, extModuleName("cats"), hasNoTests)
     .dependsOn(core, extra)
-    .settings(libraryDependencies += "org.typelevel" %%% "cats-effect" % Ver.CatsEffect)
+    .settings(
+      libraryDependencies += "org.typelevel" %%% "cats-effect" % Ver.CatsEffect
+    )
 
   // ==============================================================================================
   lazy val ghpagesMacros = Project("gh-pages-macros", file("gh-pages-macros"))

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -16,7 +16,7 @@ object ScalajsReact {
     val MacroParadise = "2.1.1"
     val SizzleJs      = "2.3.0"
     val Nyaya         = "0.8.1"
-    val Cats          = "1.0.0-RC1"
+    val CatsEffect    = "0.6"
   }
 
   type PE = Project => Project
@@ -241,7 +241,7 @@ object ScalajsReact {
   lazy val cats = project
     .configure(commonSettings, publicationSettings, extModuleName("cats"), hasNoTests)
     .dependsOn(core, extra)
-    .settings(libraryDependencies += "org.typelevel" %%% "cats-core" % Ver.Cats)
+    .settings(libraryDependencies += "org.typelevel" %%% "cats-effect" % Ver.CatsEffect)
 
   // ==============================================================================================
   lazy val ghpagesMacros = Project("gh-pages-macros", file("gh-pages-macros"))

--- a/test/src/test/scala/japgolly/scalajs/react/CatsTest.scala
+++ b/test/src/test/scala/japgolly/scalajs/react/CatsTest.scala
@@ -3,6 +3,8 @@ package japgolly.scalajs.react
 import cats.{Monad, Id, ~>}
 import cats.data.StateT
 import cats.implicits._
+import cats.effect.IO
+import cats.effect.implicits._
 
 import japgolly.scalajs.react.CatsReact._
 import japgolly.scalajs.react.test.ReactTestUtils
@@ -28,8 +30,7 @@ object CatsTest extends TestSuite {
 
       implicit val mMonad = null.asInstanceOf[Monad[M] with (M ~> CallbackTo)]
 
-      val retVal: Id[Int] = 3
-      val reactSId: ReactST[Id, S, Int] = ReactS retM retVal
+      val reactSId: ReactST[IO, S, Int] = ReactS retM IO(3)
 
       "runState(s.liftS)"   - test[StateT[M,S,A]                        ](s => bs.runState(s.liftS)  ).expect[CallbackTo[A]]
       "runStateFn(f.liftS)" - test[B => StateT[M,S,A]                   ](s => bs.runStateFn(s.liftS)).expect[B => CallbackTo[A]]

--- a/test/src/test/scala/japgolly/scalajs/react/CatsTest.scala
+++ b/test/src/test/scala/japgolly/scalajs/react/CatsTest.scala
@@ -12,6 +12,8 @@ import japgolly.scalajs.react.test.TestUtil._
 import japgolly.scalajs.react.vdom.html_<^._
 import utest._
 
+import scala.concurrent.Future
+
 /**
  * Scala's type inference can be pretty weak sometimes.
  * Successful compilation will suffice as proof for most of these tests.
@@ -30,7 +32,7 @@ object CatsTest extends TestSuite {
 
       implicit val mMonad = null.asInstanceOf[Monad[M] with (M ~> CallbackTo)]
 
-      val reactSId: ReactST[IO, S, Int] = ReactS retM IO(3)
+      val reactSId: ReactST[IO, S, Int] = ReactS retM IO.pure(3)
 
       "runState(s.liftS)"   - test[StateT[M,S,A]                        ](s => bs.runState(s.liftS)  ).expect[CallbackTo[A]]
       "runStateFn(f.liftS)" - test[B => StateT[M,S,A]                   ](s => bs.runStateFn(s.liftS)).expect[B => CallbackTo[A]]


### PR DESCRIPTION
Finally, Cats it's getting is own `IO` monad and apparently it's the best thing after sliced bread since it comes with effect-related typeclasses and laws. In relation with SJS-ReactJS this means that the Cats integration module can now provide the same integration level than the Scalaz one.

One important remark, Cat's `IO` is closer to `scalaz.Task` (and `fs2.Task` / `monix.Task`) than Scalaz's `IO`. What this means is that a `cats.effect.IO[A]` may represent an asynchronous computation in which the operation `unsafeRunSync()` will throw an Exception ScalaJS since blocking threads is not possible in JavaScript.

The solution for the previous problem is achieved by consuming the real `IO` asynchronously via `runAsync` - which will convert any `IO[A]` into a `IO[Unit]` - and then run synchronously this very last one. Something in the likes of:

```
val myIO: IO[A] = ...
val handler: Either[Throwable, A] => IO[Unit] = ...
myIO.runAsync(handler).unsafeRunSync()
```

Unfortunately it's not possible to actually do this everywhere we need to do an `.unsafeRunSync()` so I'm just leaving it as it is, open for discussion whether SJS-ReactJS should even care about this.