### PR TITLE
Expand monocle ext dependency instructions

### DIFF
--- a/doc/FP.md
+++ b/doc/FP.md
@@ -39,7 +39,13 @@ Monocle
 =======
 
 ```scala
-libraryDependencies += "com.github.japgolly.scalajs-react" %%% "ext-monocle" % "1.0.0"
+libraryDependencies ++= Seq(
+    "com.github.japgolly.scalajs-react" %%% "ext-monocle" % "1.0.0",
+    "com.github.julien-truffaut" %%%  "monocle-core"  % "1.4.0",
+    "com.github.julien-truffaut" %%%  "monocle-macro" % "1.4.0"
+)
+
+addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
 ```
 
 A module with a extensions for [Monocle](https://github.com/julien-truffaut/Monocle) also exists under `ext-monocle`.


### PR DESCRIPTION
Hi there,

Thanks for writing this library.  It kicks ass.  You're blog is interesting too!

One thing I got stumped on for quite a while was trying to work out why my `StateSnapshot` was not compiling when I tried to use Monocle lenses.  After some time I worked out that I was missing the macro paradise compiler plugin.  I thought I'd throw in a pull request to help others who make the same mistake.

I've expanded the necessary instructions in the docs to include this.  Feel free to comment and change.

Cheers,
Matt