### PR TITLE
Fix reusable functions example

### DIFF
--- a/doc/PERFORMANCE.md
+++ b/doc/PERFORMANCE.md
@@ -213,7 +213,7 @@ type PersonId = Long
 type PersonData = String
 
 val topComponent = ScalaComponent.builder[State]("Demo")
-  .initialState_P(identity)
+  .initialStateFromProps(identity)
   .renderBackend[Backend]
   .build
 
@@ -225,7 +225,7 @@ class Backend(bs: BackendScope[_, State]) {
   def render(state: State) =
     <.div(
       state.toVdomArray { case (id, name) =>
-        personEditor.withKey(id)(PersonEditorProps(name, updateUser(id))) // ← Apply 1 arg
+        personEditor.withKey(id.toString)(PersonEditorProps(name, updateUser(id))) // ← Apply 1 arg
       }
     )
 }


### PR DESCRIPTION
Couple of quick doc corrections.

Were trying to pass a `Long` to `withKey` which isn't able to be converted into a `Key`.

`withKey()` takes `Key` which is:
`type Key = String | Boolean | JsNumber | Null`
`type JsNumber = Byte | Short | Int | Float | Double`
