### PR TITLE
Additional documentation for pure React callback interop

### DIFF
--- a/doc/INTEROP.md
+++ b/doc/INTEROP.md
@@ -47,13 +47,28 @@ object ReactCollapse {
   object RawComponent extends js.Object
 
   @js.native
-  trait Props extends js.Object {
-    var isOpened: Boolean = js.native
+  trait Measures extends js.Object {
+    val height: Double = js.native
+    val width: Double = js.native
   }
 
-  def props(isOpened: Boolean): Props = {
+  type OnMeasure = js.Function1[Measures, Unit]
+  type OnRest = js.Function0[Unit]
+
+  @js.native
+  trait Props extends js.Object {
+    var isOpened: Boolean = js.native
+    var onMeasure: OnMeasure = js.native
+    var onRest: OnRest = js.native
+  }
+
+  def props(isOpened: Boolean,
+            onMeasure: Measures => Callback = _ => Callback.empty,
+            onRest: Callback = Callback.empty): Props = {
     val p = (new js.Object).asInstanceOf[Props]
     p.isOpened = isOpened
+    p.onMeasure = (measures: Measures) => onMeasure(measures).runNow()
+    p.onRest = onRest.toJsCallback // or alternatively: () => onRest.runNow()
     p
   }
 


### PR DESCRIPTION
[Partly] addresses https://github.com/japgolly/scalajs-react/issues/358 and elaborates the example to show off callback integration techniques.

I deliberately dumbed it down and didn't use `js.UndefOr` wrapper and function composition to demonstrate just the gist in a more beginner (e.g. me) friendly way.