### PR TITLE
Add references to diode and scalafiddle-editor in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ Includes a router, testing utils, performance utils, more.
   * [scalajs-benchmark](https://github.com/japgolly/scalajs-benchmark/)
   * [chandu0101 / scalajs-react-components](https://github.com/chandu0101/scalajs-react-components)
   * [payalabs / scalajs-react-mdl](https://github.com/payalabs/scalajs-react-mdl) - (Material Design Lite components)
+  * [diode](https://github.com/suzaku-io/diode) - library for managing application state, influenced by Flux and Elm
+
+* Open Source Projects, which are using [scalajs-react](https://github.com/japgolly/scalajs-react)
+  * [scastie](https://github.com/scalacenter/scastie) - An interactive playground for Scala [https://scastie.scala-lang.org](https://scastie.scala-lang.org)
+  * [scalafiddle-editor](https://github.com/scalafiddle/scalafiddle-editor) - Web user interface for ScalaFiddle [https://scalafiddle.io](https://scalafiddle.io)
 
 ##### Requirements:
 * React 15.3+


### PR DESCRIPTION
Hi, 

thanks for package!
It is really cool, that so solid ecosystem already exists around scalajs-react.

For me [diode](https://github.com/suzaku-io/diode) and [scalafiddle-editor](https://github.com/scalafiddle/scalafiddle-editor) projects were very helpful for understanding how to build frontend apps with scalajs-react.
 
I've added references to the packages in README.
