### PR TITLE
Add runStateFuture and runStateFnFuture functions

### DIFF
--- a/cats/src/main/scala/japgolly/scalajs/react/internal/CatsReactState.scala
+++ b/cats/src/main/scala/japgolly/scalajs/react/internal/CatsReactState.scala
@@ -232,13 +232,13 @@ object CatsReactState {
     def runStateFnF[I, M[_], A](f: I => ReactST[M, S, A])(implicit M: M ~> CallbackTo, N: Monad[M], F: ChangeFilter[S]): I => Out[A] =
       i => runStateF(f(i))
 
-    def runStateAsync[M[_]](st: => ReactST[M, S, Unit])(implicit F: FlatMap[M], C: M[Callback]=>Callback, ec: ExecutionContext): Callback =
+    def runStateAsync[M[_], A](st: => ReactST[M, S, A])(implicit F: FlatMap[M], C: M[Callback]=>Callback, ec: ExecutionContext): Callback =
       stateCB.flatMap { s1 =>
         val runCB = st.runS(ReactS.StateAndCallbacks(s1))
         C(F.map(runCB)(s2 => fToCb(sa.setStateCB(si)(s2.state, s2.cb))))
       }
 
-    def runStateFnAsync[M[_], I](f: I => ReactST[M, S, Unit])(implicit F: FlatMap[M], C: M[Callback]=>Callback, ec: ExecutionContext): I => Callback =
+    def runStateFnAsync[I, M[_], A](f: I => ReactST[M, S, A])(implicit F: FlatMap[M], C: M[Callback]=>Callback, ec: ExecutionContext): I => Callback =
       i => runStateAsync(f(i))
 
     def modStateF(f: S => S, cb: Callback = Callback.empty)(implicit F: ChangeFilter[S]): Out[Unit] =

--- a/cats/src/main/scala/japgolly/scalajs/react/internal/CatsReactState.scala
+++ b/cats/src/main/scala/japgolly/scalajs/react/internal/CatsReactState.scala
@@ -234,7 +234,7 @@ object CatsReactState {
     def runStateFnF[I, M[_], A](f: I => ReactST[M, S, A])(implicit M: M ~> CallbackTo, N: Monad[M], F: ChangeFilter[S]): I => Out[A] =
       i => runStateF(f(i))
 
-    def runStateAsync[M[_], A](st: => ReactST[M, S, A])(implicit N: Monad[M], ec: ExecutionContext): CallbackTo[M[A]] = {
+    def runStateAsync[M[_], A](st: => ReactST[M, S, A])(implicit N: Monad[M]): CallbackTo[M[A]] = {
       stateCB.map { s1 =>
         val runCB = st.run(ReactS.StateAndCallbacks(s1))
         runCB.map { x2 =>
@@ -247,7 +247,7 @@ object CatsReactState {
       }
     }
 
-    def runStateFnAsync[I, M[_], A](f: I => ReactST[M, S, A])(implicit N: Monad[M], ec: ExecutionContext): I => CallbackTo[M[A]] =
+    def runStateFnAsync[I, M[_], A](f: I => ReactST[M, S, A])(implicit N: Monad[M]): I => CallbackTo[M[A]] =
       i => runStateAsync(f(i))
 
     def modStateF(f: S => S, cb: Callback = Callback.empty)(implicit F: ChangeFilter[S]): Out[Unit] =

--- a/cats/src/main/scala/japgolly/scalajs/react/internal/CatsReactState.scala
+++ b/cats/src/main/scala/japgolly/scalajs/react/internal/CatsReactState.scala
@@ -44,6 +44,7 @@ object CatsReactState {
 
   type ReactST[M[_], S, A] = StateT[M, StateAndCallbacks[S], A]
   type ReactS[S, A] = ReactST[Id, S, A]
+  final type TransAsync[M[_], N[_]] = M ~> ({type X[a] = CallbackTo[N[a]]})#X
 
   object ReactS {
     final def StateAndCallbacks[S](state: S, cb: Callback = Callback.empty) =
@@ -202,8 +203,6 @@ object CatsReactState {
 
   final class Ext_StateAccessRW[F[_], SI, S, Out[_]](si: SI)(implicit sa: StateAccessor.ReadWrite[SI, F, F, S], fToCb: Effect.Trans[F, CallbackTo], cbToOut: Effect.Trans[CallbackTo, Out]) {
     implicit private def autoOut[A](a: CallbackTo[A]): Out[A] = cbToOut(a)
-
-    private type TransAsync[M[_], N[_]] = M ~> ({type X[a] = CallbackTo[N[a]]})#X
 
     private def stateCB: CallbackTo[S] = fToCb(sa.state(si))
 


### PR DESCRIPTION
I may be in over my depth, but here goes.

I would like to use the ReactS monad along with ajax requests. To accomodate this, I've added some convenience functions into the Cats StateAccessRW extension.

These allow the monad to be used as such:
```scala
object Example {
  case class State(list: List[String])

  val ST = ReactS.Fix[State]

  val home = ScalaComponent.builder[Unit]("Example")
    .initialState(State(Nil))
    .renderS { ($, s) =>
      <.div(
        ^.onClick --> $.runStateFuture(appendExample),
        <.ul(s.events.toTagMod(<.li(_)))
      )
    }
      .componentDidMount(_.runStateFuture(appendExample))
    .build

  def appendExample: ReactST[Future, Home.State, Unit] =
    ST.modM(s => Ajax.get("http://date.jsontest.com/") map (r => State(s.events :+ r.responseText)))
}
```

Hopefully there is nothing fundamentally wrong with using the monad in such a fashion.