### PR TITLE
add reference to scala-weather-app in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Includes a router, testing utils, performance utils, more.
 * Open Source Projects, which are using [scalajs-react](https://github.com/japgolly/scalajs-react)
   * [scastie](https://github.com/scalacenter/scastie) - An interactive playground for Scala [https://scastie.scala-lang.org](https://scastie.scala-lang.org)
   * [scalafiddle-editor](https://github.com/scalafiddle/scalafiddle-editor) - Web user interface for ScalaFiddle [https://scalafiddle.io](https://scalafiddle.io)
+  * [scala-weather-app](https://github.com/malaman/scala-weather-app) - Yet another weather application, based on Scala.js, scalajs-react and Playframework
 
 ##### Requirements:
 * React 15.3+


### PR DESCRIPTION
Hi,
i've added reference to [scala-weather-app](https://github.com/malaman/scala-weather-app).
The app is pretty simple, but it might give some examples about how to use js/react.js components inside scalajs-react app.