### PR TITLE
added onUploadProgrss to Ajax helper

### DIFF
--- a/doc/changelog/1.2.1.md
+++ b/doc/changelog/1.2.1.md
@@ -2,6 +2,7 @@
 
 * Bugfix: `Reusability.shouldComponentUpdateWithOverlay` no longer crashes with React 16
 * Introduced CSS grid related attributes
+* added onUploadProgress to AjaxHelper (onProgress only triggers for the download part)
 
 
 ## Detail


### PR DESCRIPTION
When using the Ajax helper to upload files, the onProgress event listener (which attaches to xhr.onprogress)  doesn't trigger. This is done separately through xhr.upload.onprogress. 

I've added onUploadProgress to the Ajax helper to attach such a listener. I was thinking if it would make sense to rename the old one to onDownloadProgress but that would break the existing API so it's maybe good enough.