### PR TITLE
added onDownloadProgress and deprecated onProgress in AjaxHelper

### DIFF
--- a/doc/changelog/1.2.1.md
+++ b/doc/changelog/1.2.1.md
@@ -4,8 +4,7 @@
 * Update monocle-cats to version 1.5.1-cats
 * Bugfix: `Reusability.shouldComponentUpdateWithOverlay` no longer crashes with React 16
 * Introduced CSS grid related attributes
-* added onUploadProgress to AjaxHelper (onProgress only triggers for the download part)
-
+* added onUploadProgress and onDownloadProgress to AjaxHelper (the now deprecated onProgress only triggered for the download part) 
 
 ## Detail
 

--- a/extra/src/main/scala/japgolly/scalajs/react/extra/Ajax.scala
+++ b/extra/src/main/scala/japgolly/scalajs/react/extra/Ajax.scala
@@ -98,7 +98,10 @@ object Ajax {
     def onTimeout(f: XMLHttpRequest => Callback): Step2 =
       copy(ontimeout = Some(CallbackKleisli(f) <<? ontimeout))
 
-    def onProgress(f: (XMLHttpRequest, ProgressEvent) => Callback): Step2 =
+    @deprecated("Use .onDownloadProgress instead", "1.2.1")
+    def onProgress(f: (XMLHttpRequest, ProgressEvent) => Callback): Step2 = onDownloadProgress(f)
+
+    def onDownloadProgress(f: (XMLHttpRequest, ProgressEvent) => Callback): Step2 =
       copy(onprogress = Some(CallbackKleisli(f.tupled) <<? onprogress))
 
     def onUploadProgress(f: (XMLHttpRequest, ProgressEvent) => Callback): Step2 =


### PR DESCRIPTION
As discussed in https://github.com/japgolly/scalajs-react/pull/465 