### PR TITLE
Add onCompleteHandle to Ajax

### DIFF
--- a/doc/changelog/1.3.2.md
+++ b/doc/changelog/1.3.2.md
@@ -1,0 +1,3 @@
+## 1.3.2
+
+* Add `onCompleteHandle` to Ajax


### PR DESCRIPTION
Add `onCompleteTry` to Ajax so that its easier to pattern match against ajax response, e.g.

```
Ajax(req.method, req.url)
    .send(req.body)
    .onCompleteTry { 
      case Success(xhr) => ...
      case Failure(AjaxException(xhr)) => ....
    }
```