### PR TITLE
Fix the import of `raw.Suspense` when using a module system

### DIFF
--- a/core/src/main/scala/japgolly/scalajs/react/raw/Suspense.scala
+++ b/core/src/main/scala/japgolly/scalajs/react/raw/Suspense.scala
@@ -3,7 +3,7 @@ package japgolly.scalajs.react.raw
 import scala.scalajs.js
 import scala.scalajs.js.annotation.JSImport
 
-@JSImport("react", JSImport.Namespace, "React.Suspense")
+@JSImport("react", "Suspense", "React.Suspense")
 @js.native
 object Suspense extends js.Any
 

--- a/doc/changelog/1.4.1.md
+++ b/doc/changelog/1.4.1.md
@@ -1,0 +1,3 @@
+## 1.4.1
+
+* Fixed `React.Suspense` import when compiling for a module system (for example when using ScalaJS-Bundler)


### PR DESCRIPTION
Fixes #522, see https://github.com/japgolly/scalajs-react/issues/522#issuecomment-472864459 and https://github.com/japgolly/scalajs-react/issues/522#issuecomment-472867501 for more details.