### PR TITLE
Fix AsyncCallback & Ajax repeatability

### DIFF
--- a/core/src/main/scala/japgolly/scalajs/react/AsyncCallback.scala
+++ b/core/src/main/scala/japgolly/scalajs/react/AsyncCallback.scala
@@ -194,8 +194,8 @@ final class AsyncCallback[A] private[AsyncCallback] (val completeWith: (Try[A] =
   @inline def >>=[B](g: A => AsyncCallback[B]): AsyncCallback[B] =
     flatMap(g)
 
-  def flatten[B](implicit ev: AsyncCallback[A] =:= AsyncCallback[AsyncCallback[B]]): AsyncCallback[B] =
-    ev(this).flatMap(identityFn)
+  def flatten[B](implicit ev: A => AsyncCallback[B]): AsyncCallback[B] =
+    flatMap(ev)
 
   /** Sequence the argument a callback to run after this, discarding any value produced by this. */
   def >>[B](runNext: AsyncCallback[B]): AsyncCallback[B] =

--- a/core/src/main/scala/japgolly/scalajs/react/AsyncCallback.scala
+++ b/core/src/main/scala/japgolly/scalajs/react/AsyncCallback.scala
@@ -32,10 +32,10 @@ object AsyncCallback {
     } yield (fromJsPromise(p), pc)
 
   def first[A](f: (Try[A] => Callback) => Callback): AsyncCallback[A] =
-    new AsyncCallback(g => {
+    new AsyncCallback(g => CallbackTo {
       var first = true
       f(ea => Callback.when(first)(Callback{first = false} >> g(ea)))
-    })
+    }.flatten)
 
   def point[A](a: => A): AsyncCallback[A] =
     AsyncCallback(_(catchAll(a)))

--- a/doc/changelog/1.4.2.md
+++ b/doc/changelog/1.4.2.md
@@ -2,3 +2,4 @@
 
 * `AsyncCallback` bugfixes:
   * `a.race(b).toCallback` should start a new race each time the `Callback` is invoked
+  * `a.flatten` wouldn't compile (oops)

--- a/doc/changelog/1.4.2.md
+++ b/doc/changelog/1.4.2.md
@@ -1,5 +1,6 @@
 ## 1.4.2
 
-* `AsyncCallback` bugfixes:
-  * `a.race(b).toCallback` should start a new race each time the `Callback` is invoked
-  * `a.flatten` wouldn't compile (oops)
+* Bugfixes
+  * `Ajax…asAsyncCallback…toCallback` should make new AJAX calls each time the `Callback` is invoked
+  * `AsyncCallback#race(…).toCallback` should start a new race each time the `Callback` is invoked
+  * `AsyncCallback#flatten` wouldn't compile (oops)

--- a/doc/changelog/1.4.2.md
+++ b/doc/changelog/1.4.2.md
@@ -1,0 +1,4 @@
+## 1.4.2
+
+* `AsyncCallback` bugfixes:
+  * `a.race(b).toCallback` should start a new race each time the `Callback` is invoked

--- a/gh-pages/src/main/scala/ghpages/secret/tests/QuickTest.scala
+++ b/gh-pages/src/main/scala/ghpages/secret/tests/QuickTest.scala
@@ -11,9 +11,15 @@ object QuickTest {
     case object NotStarted extends Status
     case object InProgress extends Status
 
-    sealed trait Result extends Status
-    case object Pass extends Result
-    final case class Fail(error: String) extends Result
+    sealed trait Result extends Status {
+      def &&(r: => Result): Result
+    }
+    case object Pass extends Result {
+      override def &&(r: => Result) = r
+    }
+    final case class Fail(error: String) extends Result {
+      override def &&(r: => Result) = this
+    }
   }
 
   final case class Test(name: String,

--- a/test/src/test/scala/japgolly/scalajs/react/core/AsyncCallbackTest.scala
+++ b/test/src/test/scala/japgolly/scalajs/react/core/AsyncCallbackTest.scala
@@ -20,13 +20,17 @@ object AsyncCallbackTest extends TestSuite {
       'async {
         val cb = log("async").async.toCallback >> log("post")
         cb.runNow()
-        log.logs ==> Vector("post")
+        log.logs ==> Vector("post") // "async" will be scheduled by JS sometime after this test
+        cb.runNow()
+        log.logs ==> Vector("post", "post")
       }
 
       'asAsyncCallback {
         val cb = log("async").asAsyncCallback.toCallback >> log("post")
         cb.runNow()
         log.logs ==> Vector("async", "post")
+        cb.runNow()
+        log.logs ==> Vector("async", "post", "async", "post")
       }
     }
 


### PR DESCRIPTION
`Callback`s are meant to be repeatable in that they're supposed to perform the same action each time they're invoked. If you have a `Callback` that makes an AJAX call (especially if created via the `Ajax` helper), you should be able to invoke it multiple times (eg. to retry on failure) and have it make new calls each invocation. This isn't the case in 1.4.1 but this PR fixes this.