### PR TITLE
Make AsyncCallback.fromFuture sync if the Future it is derived from is

### DIFF
--- a/core/src/main/scala/japgolly/scalajs/react/AsyncCallback.scala
+++ b/core/src/main/scala/japgolly/scalajs/react/AsyncCallback.scala
@@ -105,7 +105,11 @@ object AsyncCallback {
 
   def fromFuture[A](fa: => Future[A])(implicit ec: ExecutionContext): AsyncCallback[A] =
     AsyncCallback(f => Callback {
-      fa.onComplete(f(_).runNow())
+      val future = fa
+      future.value match {
+        case Some(value) => f(value).runNow()
+        case None => future.onComplete(f(_).runNow())
+      }
     })
 
   def fromCallbackToFuture[A](c: CallbackTo[Future[A]])(implicit ec: ExecutionContext): AsyncCallback[A] =

--- a/test/src/test/scala/japgolly/scalajs/react/core/AsyncCallbackTest.scala
+++ b/test/src/test/scala/japgolly/scalajs/react/core/AsyncCallbackTest.scala
@@ -2,6 +2,8 @@ package japgolly.scalajs.react.core
 
 import japgolly.scalajs.react.{AsyncCallback, Callback}
 import utest._
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
 
 object AsyncCallbackTest extends TestSuite {
 
@@ -31,6 +33,21 @@ object AsyncCallbackTest extends TestSuite {
         log.logs ==> Vector("async", "post")
         cb.runNow()
         log.logs ==> Vector("async", "post", "async", "post")
+      }
+    }
+
+    'AsyncCallback {
+      'fromFuture {
+        "should be sync if the Future has already completed" - {
+          var hasRun = false
+          val cb = AsyncCallback.fromFuture(Future.successful(()))
+          cb.completeWith(_ => Callback {
+            hasRun = true
+          }).runNow()
+          hasRun ==> true
+          val future = cb.asCallbackToFuture.runNow()
+          future.isCompleted ==> true
+        }
       }
     }
 


### PR DESCRIPTION
Fixes #528. This is important for avoiding glitches when using Suspense with
external libraries (which often use Futures as a common interchange type for
async tasks). It's also nice to avoid the ScalaJS-React dependency in non-view
code.