### PR TITLE
Update kind-projector from 0.9.10 to 0.10.3

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -12,7 +12,7 @@ object ScalajsReact {
   object Ver {
     val BetterMonadicFor = "0.3.0"
     val Cats             = "1.6.0"
-    val KindProjector    = "0.9.10"
+    val KindProjector    = "0.10.3"
     val MacroParadise    = "2.1.1"
     val Monocle          = "1.5.0"
     val MonocleCats      = "1.5.1-cats"
@@ -177,7 +177,7 @@ object ScalajsReact {
     compilerPlugin("org.scalamacros" % "paradise" % Ver.MacroParadise cross CrossVersion.full)
 
   def kindProjector =
-    compilerPlugin("org.spire-math" %% "kind-projector" % Ver.KindProjector cross CrossVersion.binary)
+    compilerPlugin("org.typelevel" %% "kind-projector" % Ver.KindProjector cross CrossVersion.binary)
 
   def hasNoTests: Project => Project =
     _.settings(


### PR DESCRIPTION
Earlier version than 0.10.0 were released under a different organization
(From 'org.spire-math' to 'org.typelevel')

https://mvnrepository.com/artifact/org.spire-math/kind-projector
https://mvnrepository.com/artifact/org.typelevel/kind-projector

Helping @scala-steward to updated libraries 

This is blocking https://github.com/japgolly/scalajs-react/issues/556 