### PR TITLE
MonadError.raiseError for AsyncCallback was not suspending execution.

### DIFF
--- a/cats/src/main/scala/japgolly/scalajs/react/internal/CatsReactInstances.scala
+++ b/cats/src/main/scala/japgolly/scalajs/react/internal/CatsReactInstances.scala
@@ -55,7 +55,7 @@ trait CatsReactInstances {
       AsyncCallback.tailrec(a)(f)
 
     override def raiseError[A](e: Throwable): AsyncCallback[A] =
-      AsyncCallback(throw e)
+      AsyncCallback.throwException(e)
 
     override def handleErrorWith[A](fa: AsyncCallback[A])(f: Throwable => AsyncCallback[A]): AsyncCallback[A] =
       fa.attempt.flatMap {


### PR DESCRIPTION
MonadError[AsyncCallback, Throwable].raiseError would raise the exception as soon as called.