### PR TITLE
Derive cats.Monad+Monoid for Effect.Sync.

### DIFF
--- a/callback/src/main/scala-3/japgolly/scalajs/react/callback/CallbackOption.scala
+++ b/callback/src/main/scala-3/japgolly/scalajs/react/callback/CallbackOption.scala
@@ -280,7 +280,7 @@ final class CallbackOption[+A](val underlyingRepr: CallbackOption.UnderlyingRepr
    *
    * @param cond The condition required to be `true` for this callback to execute.
    */
-  def when(inline cond: Boolean): CallbackOption[A] =
+  def when(cond: Boolean): CallbackOption[A] =
     new CallbackOption[A](() => if (cond) cbfn() else None)
 
   /**
@@ -298,7 +298,7 @@ final class CallbackOption[+A](val underlyingRepr: CallbackOption.UnderlyingRepr
    * @param cond The condition required to be `false` for this callback to execute.
    * @return `Some` result of the callback executed, else `None`.
    */
-  inline def unless(inline cond: Boolean): CallbackOption[A] =
+  def unless(cond: Boolean): CallbackOption[A] =
     when(!cond)
 
   /**

--- a/callback/src/main/scala-3/japgolly/scalajs/react/callback/CallbackOption.scala
+++ b/callback/src/main/scala-3/japgolly/scalajs/react/callback/CallbackOption.scala
@@ -32,6 +32,9 @@ object CallbackOption {
   inline def delay[A](inline a: A): CallbackOption[A] =
     option(Some(a))
 
+  def suspend[A](f: => CallbackOption[A]): CallbackOption[A] =
+    delay(f).flatMap(identityFn)
+
   inline def option[A](inline oa: Option[A]): CallbackOption[A] =
     new CallbackOption(() => oa)
 
@@ -277,8 +280,16 @@ final class CallbackOption[+A](val underlyingRepr: CallbackOption.UnderlyingRepr
    *
    * @param cond The condition required to be `true` for this callback to execute.
    */
-  inline def when(inline cond: Boolean): CallbackOption[A] =
+  def when(inline cond: Boolean): CallbackOption[A] =
     new CallbackOption[A](() => if (cond) cbfn() else None)
+
+  /**
+   * Conditional execution of this callback.
+   *
+   * @param cond The condition required to be `true` for this callback to execute.
+   */
+  def when_(cond: => Boolean): CallbackOption[Unit] =
+    new CallbackOption[Unit](() => if (cond) cbfn().map(_ => ()) else None)
 
   /**
    * Conditional execution of this callback.
@@ -289,6 +300,16 @@ final class CallbackOption[+A](val underlyingRepr: CallbackOption.UnderlyingRepr
    */
   inline def unless(inline cond: Boolean): CallbackOption[A] =
     when(!cond)
+
+  /**
+   * Conditional execution of this callback.
+   * Reverse of [[when_()]].
+   *
+   * @param cond The condition required to be `false` for this callback to execute.
+   * @return `Some` result of the callback executed, else `None`.
+   */
+  inline def unless_(cond: => Boolean): CallbackOption[Unit] =
+    when_(!cond)
 
   def orElse[AA >: A](tryNext: CallbackOption[AA]): CallbackOption[AA] =
     new CallbackOption(() => cbfn().orElse(tryNext.underlyingRepr()))
@@ -307,4 +328,10 @@ final class CallbackOption[+A](val underlyingRepr: CallbackOption.UnderlyingRepr
 
   def handleError[AA >: A](f: Throwable => CallbackOption[AA]): CallbackOption[AA] =
     asCallback.handleError(f(_).asCallback).asCBO
+
+  /** Wraps this callback in a `try-finally` block and runs the given callback in the `finally` clause, after the
+    * current callback completes, be it in error or success.
+    */
+  def finallyRun[B](runFinally: CallbackOption[B]): CallbackOption[A] =
+    asCallback.finallyRun(runFinally.asCallback).asCBO
 }

--- a/coreExtCats/src/main/scala/japgolly/scalajs/react/ReactCats.scala
+++ b/coreExtCats/src/main/scala/japgolly/scalajs/react/ReactCats.scala
@@ -1,9 +1,12 @@
 package japgolly.scalajs.react
 
+import cats.MonadThrow
+import cats.Monoid
 import cats.arrow.Profunctor
 import cats.data.Ior
 import cats.kernel.Eq
 import japgolly.scalajs.react.internal.CoreGeneral.Key
+import japgolly.scalajs.react.util.Effect
 import scala.annotation.nowarn
 
 object ReactCats extends ReactCats
@@ -23,4 +26,10 @@ trait ReactCats {
 
   @inline final implicit def reactCatsProfunctorRefFull[F[_], X]: Profunctor[Ref.FullF[F, *, X, *]] =
     X.reactCatsProfunctorRefFull
+
+  @inline final implicit def reactCatsSyncEffectMonadThrow[F[_]: Effect.Sync]: MonadThrow[F] =
+    X.reactCatsSyncEffectMonadThrow
+
+  @inline final implicit def reactCatsSyncEffectMonoid[F[_]: Effect.Sync, A: Monoid]: Monoid[F[A]] =
+    X.reactCatsSyncEffectMonoid
 }

--- a/coreExtCats/src/main/scala/japgolly/scalajs/react/ReactCats.scala
+++ b/coreExtCats/src/main/scala/japgolly/scalajs/react/ReactCats.scala
@@ -1,10 +1,9 @@
 package japgolly.scalajs.react
 
-import cats.MonadThrow
-import cats.Monoid
 import cats.arrow.Profunctor
 import cats.data.Ior
 import cats.kernel.Eq
+import cats.{MonadThrow, Monoid}
 import japgolly.scalajs.react.internal.CoreGeneral.Key
 import japgolly.scalajs.react.util.Effect
 import scala.annotation.nowarn
@@ -27,9 +26,9 @@ trait ReactCats {
   @inline final implicit def reactCatsProfunctorRefFull[F[_], X]: Profunctor[Ref.FullF[F, *, X, *]] =
     X.reactCatsProfunctorRefFull
 
-  @inline final implicit def reactCatsSyncEffectMonadThrow[F[_]: Effect.Sync]: MonadThrow[F] =
+  @inline final implicit def reactCatsSyncEffectMonadThrow[F[_]: Effect]: MonadThrow[F] =
     X.reactCatsSyncEffectMonadThrow
 
-  @inline final implicit def reactCatsSyncEffectMonoid[F[_]: Effect.Sync, A: Monoid]: Monoid[F[A]] =
+  @inline final implicit def reactCatsSyncEffectMonoid[F[_]: Effect, A: Monoid]: Monoid[F[A]] =
     X.reactCatsSyncEffectMonoid
 }

--- a/coreExtCats/src/main/scala/japgolly/scalajs/react/internal/ReactCats.scala
+++ b/coreExtCats/src/main/scala/japgolly/scalajs/react/internal/ReactCats.scala
@@ -35,28 +35,28 @@ object ReactCats {
       override def dimap[A, B, C, D](r: Ref.FullF[F, A, X, B])(f: C => A)(g: B => D) = r.contramap(f).map(g)
     }
 
-    implicit def reactCatsSyncEffectMonadThrow[F[_]](implicit F: Effect.Sync[F]): MonadThrow[F] =
-      new MonadThrow[F] {
-        override def flatMap[A, B](fa: F[A])(f: A => F[B]): F[B] = F.flatMap(fa)(f)
+  implicit def reactCatsSyncEffectMonadThrow[F[_]](implicit F: Effect.Sync[F]): MonadThrow[F] =
+    new MonadThrow[F] {
+      override def flatMap[A, B](fa: F[A])(f: A => F[B]): F[B] = F.flatMap(fa)(f)
 
-        override def tailRecM[A, B](a: A)(f: A => F[Either[A,B]]): F[B] = F.pure {
-          @tailrec
-          def go(a: A): B =
-            F.runSync(f(a)) match {
-              case Left(n)  => go(n)
-              case Right(b) => b
-            }
-          go(a)
-        }
-
-        override def pure[A](a: A): F[A] = F.pure(a)
-
-        override def raiseError[A](e: Throwable): F[A] = F.throwException(e)
-
-        override def handleErrorWith[A](fa: F[A])(f: Throwable => F[A]): F[A] =
-          F.handleError(fa)(f)
+      override def tailRecM[A, B](a: A)(f: A => F[Either[A,B]]): F[B] = F.pure {
+        @tailrec
+        def go(a: A): B =
+          F.runSync(f(a)) match {
+            case Left(n)  => go(n)
+            case Right(b) => b
+          }
+        go(a)
       }
 
-    implicit def reactCatsSyncEffectMonoid[F[_]: Effect.Sync, A: Monoid]: Monoid[F[A]] =
-      Applicative.monoid[F, A]
+      override def pure[A](a: A): F[A] = F.pure(a)
+
+      override def raiseError[A](e: Throwable): F[A] = F.throwException(e)
+
+      override def handleErrorWith[A](fa: F[A])(f: Throwable => F[A]): F[A] =
+        F.handleError(fa)(f)
+    }
+
+  implicit def reactCatsSyncEffectMonoid[F[_]: Effect.Sync, A: Monoid]: Monoid[F[A]] =
+    Applicative.monoid[F, A]
 }

--- a/coreExtCats/src/main/scala/japgolly/scalajs/react/internal/ReactCats.scala
+++ b/coreExtCats/src/main/scala/japgolly/scalajs/react/internal/ReactCats.scala
@@ -4,6 +4,8 @@ import cats._
 import cats.arrow.{Profunctor => CatsProfunctor}
 import cats.data.Ior
 import japgolly.scalajs.react.{ReactExtensions, Ref, Reusability}
+import japgolly.scalajs.react.util.Effect
+import scala.annotation.tailrec
 
 object ReactCats {
   import ReactExtensions._
@@ -32,4 +34,29 @@ object ReactCats {
       override def rmap[A, B, C](f: Ref.FullF[F, A, X, B])(m: B => C) = f.map(m)
       override def dimap[A, B, C, D](r: Ref.FullF[F, A, X, B])(f: C => A)(g: B => D) = r.contramap(f).map(g)
     }
+
+    implicit def reactCatsSyncEffectMonadThrow[F[_]](implicit F: Effect.Sync[F]): MonadThrow[F] =
+      new MonadThrow[F] {
+        override def flatMap[A, B](fa: F[A])(f: A => F[B]): F[B] = F.flatMap(fa)(f)
+
+        override def tailRecM[A, B](a: A)(f: A => F[Either[A,B]]): F[B] = F.pure {
+          @tailrec
+          def go(a: A): B =
+            F.runSync(f(a)) match {
+              case Left(n)  => go(n)
+              case Right(b) => b
+            }
+          go(a)
+        }
+
+        override def pure[A](a: A): F[A] = F.pure(a)
+
+        override def raiseError[A](e: Throwable): F[A] = F.throwException(e)
+
+        override def handleErrorWith[A](fa: F[A])(f: Throwable => F[A]): F[A] =
+          F.handleError(fa)(f)
+      }
+
+    implicit def reactCatsSyncEffectMonoid[F[_]: Effect.Sync, A: Monoid]: Monoid[F[A]] =
+      Applicative.monoid[F, A]
 }

--- a/coreExtCats/src/test/scala/japgolly/scalajs/react/ReactCatsCompilationTest.scala
+++ b/coreExtCats/src/test/scala/japgolly/scalajs/react/ReactCatsCompilationTest.scala
@@ -1,0 +1,18 @@
+package japgolly.scalajs.react
+
+import cats._
+import japgolly.scalajs.react.ReactCats._
+import japgolly.scalajs.react.util._
+
+object ReactCatsCompilationTest {
+
+  def monadThrowA [F[_]](implicit F: Effect.Async[F]                    ): MonadThrow[F] = implicitly
+  def monadThrowAS[F[_]](implicit F: Effect.Async[F] with Effect.Sync[F]): MonadThrow[F] = implicitly
+  def monadThrowS [F[_]](implicit F: Effect.Sync[F]                     ): MonadThrow[F] = implicitly
+  def monadThrowSA[F[_]](implicit F: Effect.Sync[F] with Effect.Async[F]): MonadThrow[F] = implicitly
+
+  def monoidA [F[_], A](implicit F: Effect.Async[F]                    , A: Monoid[A]): Monoid[F[A]] = implicitly
+  def monoidAS[F[_], A](implicit F: Effect.Async[F] with Effect.Sync[F], A: Monoid[A]): Monoid[F[A]] = implicitly
+  def monoidS [F[_], A](implicit F: Effect.Sync[F]                     , A: Monoid[A]): Monoid[F[A]] = implicitly
+  def monoidSA[F[_], A](implicit F: Effect.Sync[F] with Effect.Async[F], A: Monoid[A]): Monoid[F[A]] = implicitly
+}

--- a/coreExtCatsEffect/src/main/scala/japgolly/scalajs/react/util/EffectCatsEffect.scala
+++ b/coreExtCatsEffect/src/main/scala/japgolly/scalajs/react/util/EffectCatsEffect.scala
@@ -1,9 +1,11 @@
 package japgolly.scalajs.react.util
 
+import cats.Monad
 import cats.effect.unsafe.IORuntime
 import cats.effect.{IO, SyncIO}
 import japgolly.scalajs.react.ReactCatsEffect
-import scala.util.Try
+import japgolly.scalajs.react.util.Util.identityFn
+import scala.util.{Success, Try}
 
 abstract class EffectFallbacks2 extends EffectFallbacks3 {
   implicit def syncIO: Effect.Sync [SyncIO] = EffectCatsEffect.syncIO
@@ -14,6 +16,7 @@ object EffectCatsEffect {
   import Effect._
 
   implicit object syncIO extends Sync.WithDefaults[SyncIO] {
+    private[this] final val M = Monad[SyncIO]
 
     override val empty =
       SyncIO.unit
@@ -35,14 +38,15 @@ object EffectCatsEffect {
 
     @inline override def runSync[A](f: => SyncIO[A]) =
       f.unsafeRunSync()
+
+    override def tailrec[A, B](a: A)(f: A => SyncIO[Either[A, B]]) =
+      M.tailRecM(a)(f)
   }
 
   // ===================================================================================================================
 
-  implicit lazy val io: AsyncIO =
-    new AsyncIO(ReactCatsEffect.runtimeFn)
-
-  class AsyncIO(runtime: () => IORuntime) extends Async.WithDefaults[IO] {
+  class EffectIO extends Effect[IO] {
+    protected final val M = Monad[IO]
 
     @inline override def delay[A](a: => A) =
       IO.delay(a)
@@ -56,10 +60,27 @@ object EffectCatsEffect {
     @inline override def flatMap[A, B](fa: IO[A])(f: A => IO[B]) =
       fa.flatMap(f)
 
-    override def finallyRun[A, B](fa: IO[A], fb: IO[B]) =
+    override def finallyRun[A, B](fa: => IO[A], fb: => IO[B]) =
       fa.attempt.flatMap(ta =>
       fb.attempt.flatMap(tb =>
       IO.fromEither(if (ta.isRight && tb.isLeft) Left(tb.left.getOrElse(null)) else ta)))
+
+    override def tailrec[A, B](a: A)(f: A => IO[Either[A, B]]) =
+      M.tailRecM(a)(f)
+
+    override def handleError[A, AA >: A](fa: => IO[A])(f: Throwable => IO[AA]) =
+      fa.handleErrorWith(f)
+
+    override def suspend[A](fa: => IO[A]) =
+      IO(fa).flatMap(identityFn)
+  }
+
+  // ===================================================================================================================
+
+  implicit lazy val io: AsyncIO =
+    new AsyncIO(ReactCatsEffect.runtimeFn)
+
+  class AsyncIO(runtime: () => IORuntime) extends EffectIO with Async.WithDefaults[IO] {
 
     override def async[A](fa: Async.Untyped[A]): IO[A] =
       IO.async(f => IO.delay {
@@ -82,5 +103,5 @@ object EffectCatsEffect {
   }
 
   private lazy val tryUnit: Try[Unit] =
-    Try(())
+    Success(())
 }

--- a/coreExtCatsEffect/src/test/scala/japgolly/scalajs/react/util/ReactCatsEffectCompilationTest.scala
+++ b/coreExtCatsEffect/src/test/scala/japgolly/scalajs/react/util/ReactCatsEffectCompilationTest.scala
@@ -1,0 +1,12 @@
+package japgolly.scalajs.react.util
+
+import cats._
+import cats.effect._
+import japgolly.scalajs.react.ReactCats._
+import japgolly.scalajs.react.util.EffectCatsEffect._
+
+object ReactCatsEffectCompilationTest {
+
+  Monoid[IO[Unit]]
+  Monoid[SyncIO[Int]]
+}

--- a/doc/changelog/2.0.0-RCs.md
+++ b/doc/changelog/2.0.0-RCs.md
@@ -78,3 +78,17 @@ Contents:
 # Changes in RC5
 
 * Add a new bundle called `core-bundle-cb_io` with provides core scalajs-react functionality with `Callback` as the default sync effect and `cats.effect.IO` as the default async effect. (Thanks [@rpiaggio](https://github.com/rpiaggio))
+
+# Changes in between RC5 and 2.0.0 final
+
+* Add to callback module:
+  * `CallbackOption.suspend[A](f: => CallbackOption[A]): CallbackOption[A]`
+  * `CallbackOption.traverse_`
+  * `CallbackOption.sequence_`
+  * `CallbackOption#finallyRun[B](runFinally: CallbackOption[B]): CallbackOption[A]`
+  * `CallbackOption#when_`
+  * `CallbackOption#unless_`
+* Add to cats module:
+  * Implicit `MonadThrow` instances for scalajs-react effect types
+  * Implicit `Monoid` instances for scalajs-react effect types with a monoidal value
+* Refactoring around internal effect-agnosticism type class definitions

--- a/doc/changelog/2.0.0.md
+++ b/doc/changelog/2.0.0.md
@@ -82,10 +82,24 @@ Contents:
 * Add to `AsyncCallback` instances:
   * `def reset: AsyncCallback[Unit]` -- If this completes successfully, discard the result. If any exception occurs, call `printStackTrace` and continue.
 
+* Add to `object CallbackOption`:
+  * `def suspend[A](f: => CallbackOption[A]): CallbackOption[A]`
+  * `def traverse_`
+  * `def sequence_`
+
+* Add to `CallbackOption` instances:
+  * `def finallyRun[B](runFinally: CallbackOption[B]): CallbackOption[A]`
+  * `def when_(cond: => Boolean): CallbackOption[Unit]`
+  * `def unless_(cond: => Boolean): CallbackOption[Unit]`
+
 * New extension method `showDom(): String` available on mounted components given
   `import japgolly.scalajs.react.test._` and/or `import japgolly.scalajs.react.test.ReactTestUtil._`
 
 * Add `Reusable.emptyVdom` which has the type `Reusable[TagMod]`
+
+* Add to cats module:
+  * Implicit `MonadThrow` instances for scalajs-react effect types
+  * Implicit `Monoid` instances for scalajs-react effect types with a monoidal value
 
 
 # Removals

--- a/util/src/main/scala/japgolly/scalajs/react/util/Effect.scala
+++ b/util/src/main/scala/japgolly/scalajs/react/util/Effect.scala
@@ -1,21 +1,37 @@
 package japgolly.scalajs.react.util
 
 import japgolly.scalajs.react.util.Util.identityFn
+import scala.annotation.tailrec
 import scala.scalajs.js
 import scala.util.Try
 
+trait Effect[F[_]] extends Monad[F] {
+  def delay      [A]         (a: => A)                           : F[A]
+  def handleError[A, AA >: A](fa: => F[A])(f: Throwable => F[AA]): F[AA]
+  def suspend    [A]         (fa: => F[A])                       : F[A]
+
+  /** Wraps this callback in a `try-finally` block and runs the given callback in the `finally` clause, after the
+    * current callback completes, be it in error or success.
+    */
+  def finallyRun[A, B](fa: => F[A], runFinally: => F[B]): F[A]
+
+  @inline final def throwException[A](t: Throwable): F[A] =
+    delay(throw t)
+}
+
 object Effect extends EffectFallbacks {
 
-  trait Dispatch[F[_]] extends Monad[F] {
+  trait WithDefaults[F[_]] extends Effect[F] {
+  }
+
+  trait Dispatch[F[_]] extends Effect[F] {
     /** Fire and forget, could be sync or async */
     def dispatch[A](fa: F[A]): Unit
     def dispatchFn[A](fa: => F[A]): js.Function0[Unit]
-
-    def throwException[A](t: Throwable): F[A] = delay(throw t)
   }
 
   object Dispatch {
-    trait WithDefaults[F[_]] extends Dispatch[F] {
+    trait WithDefaults[F[_]] extends Dispatch[F] with Effect.WithDefaults[F] {
       override def dispatchFn[A](fa: => F[A]): js.Function0[Unit] =
         () => dispatch(fa)
     }
@@ -26,10 +42,16 @@ object Effect extends EffectFallbacks {
   type Id[A] = A
 
   trait UnsafeSync[F[_]] extends Dispatch[F] {
+    def runSync     [A]   (fa: => F[A])                     : A
+    def sequence_   [A]   (fas: => Iterable[F[A]])          : F[Unit]
+    def sequenceList[A]   (fas: => List[F[A]])              : F[List[A]]
+    def toJsFn      [A]   (fa: => F[A])                     : js.Function0[A]
+    def traverse_   [A, B](as: => Iterable[A])(f: A => F[B]): F[Unit]
+    def traverseList[A, B](as: => List[A])(f: A => F[B])    : F[List[B]]
+    def when_       [A]   (cond: => Boolean)(fa: => F[A])   : F[Unit]
 
-    def runSync[A](fa: => F[A]) : A
-    def suspend[A](fa: => F[A]) : F[A]
-    def toJsFn [A](fa: => F[A]) : js.Function0[A]
+    @inline final def unless_[A](cond: => Boolean)(fa: => F[A]): F[Unit] =
+      when_(!cond)(fa)
 
     final def subst[G[_], X[_[_]]](xg: X[G])(xf: => X[F])(implicit g: UnsafeSync[G]): X[F] =
       if (this eq g) xg.asInstanceOf[X[F]] else xf
@@ -88,12 +110,37 @@ object Effect extends EffectFallbacks {
     }
 
     implicit lazy val id: UnsafeSync[Id] = new WithDefaults[Id] {
-      override def dispatch[A]   (a: A)            = ()
-      override def delay   [A]   (a: => A)         = a
-      override def pure    [A]   (a: A)            = a
-      override def map     [A, B](a: A)(f: A => B) = f(a)
-      override def flatMap [A, B](a: A)(f: A => B) = f(a)
-      override def runSync [A]   (a: => A)         = a
+
+      override def delay       [A]   (a: => A)                       = a
+      override def dispatch    [A]   (a: A)                          = ()
+      override def finallyRun  [A, B](a: => A, runFinally: => B)     = try a finally runFinally
+      override def flatMap     [A, B](a: A)(f: A => B)               = f(a)
+      override def map         [A, B](a: A)(f: A => B)               = f(a)
+      override def pure        [A]   (a: A)                          = a
+      override def runSync     [A]   (a: => A)                       = a
+      override def sequenceList[A]   (as: => List[A])                = as
+      override def traverse_   [A, B](as: => Iterable[A])(f: A => B) = as.foreach(f)
+      override def traverseList[A, B](as: => List[A])(f: A => B)     = as.map(f)
+      override def when_       [A]   (cond: => Boolean)(a: => A)     = if (cond) a
+
+      override def tailrec[A, B](a: A)(f: A => Either[A, B]): B = {
+        @tailrec
+        def go(a: A): B =
+          f(a) match {
+            case Left(n)  => go(n)
+            case Right(b) => b
+          }
+        go(a)
+      }
+
+      override def handleError[A, AA >: A](a: => A)(f: Throwable => AA): AA =
+        try a catch { case t: Throwable => f(t) }
+
+      override def sequence_[A](as: => Iterable[A]): Unit = {
+        val i = as.iterator
+        while (i.hasNext)
+          i.next()
+      }
     }
   }
 
@@ -105,24 +152,10 @@ object Effect extends EffectFallbacks {
     val semigroupSyncOr: Semigroup[F[Boolean]]
     implicit val semigroupSyncUnit: Semigroup[F[Unit]]
 
-    def fromJsFn0   [A]         (f: js.Function0[A])              : F[A]
-    def handleError [A, AA >: A](fa: F[A])(f: Throwable => F[AA]) : F[AA]
-    def isEmpty     [A]         (f: F[A])                         : Boolean
-    def reset       [A]         (fa: F[A])                        : F[Unit]
-    def runAll      [A]         (callbacks: F[A]*)                : F[Unit]
-    def sequence_   [A]         (fas: => Iterable[F[A]])          : F[Unit]
-    def sequenceList[A]         (fas: => List[F[A]])              : F[List[A]]
-    def traverse_   [A, B]      (as: => Iterable[A])(f: A => F[B]): F[Unit]
-    def traverseList[A, B]      (as: => List[A])(f: A => F[B])    : F[List[B]]
-    def when_       [A]         (cond: => Boolean)(fa: => F[A])   : F[Unit]
-
-    /** Wraps this callback in a `try-finally` block and runs the given callback in the `finally` clause, after the
-      * current callback completes, be it in error or success.
-      */
-    def finallyRun[A, B](fa: F[A], runFinally: F[B]): F[A]
-
-    @inline final def unless_[A](cond: => Boolean)(fa: => F[A]): F[Unit] =
-      when_(!cond)(fa)
+    def fromJsFn0[A](f: js.Function0[A]): F[A]
+    def isEmpty  [A](f: F[A])           : Boolean
+    def reset    [A](fa: F[A])          : F[Unit]
+    def runAll   [A](callbacks: F[A]*)  : F[Unit]
   }
 
   object Sync {
@@ -139,10 +172,13 @@ object Effect extends EffectFallbacks {
       override def fromJsFn0[A](f: js.Function0[A]) =
         delay(f())
 
+      override def runAll[A](callbacks: F[A]*): F[Unit] =
+        callbacks.foldLeft(empty)((x, y) => chain(x, reset(y)))
+
       /** Wraps this callback in a `try-finally` block and runs the given callback in the `finally` clause, after the
         * current callback completes, be it in error or success.
         */
-      override def finallyRun[A, B](fa: F[A], runFinally: F[B]): F[A] =
+      override def finallyRun[A, B](fa: => F[A], runFinally: => F[B]): F[A] =
         delay { try runSync(fa) finally runSync(runFinally) }
 
       override def reset[A](fa: F[A]): F[Unit] =
@@ -154,9 +190,6 @@ object Effect extends EffectFallbacks {
               t.printStackTrace()
           }
         )
-
-      override def runAll[A](callbacks: F[A]*): F[Unit] =
-        callbacks.foldLeft(empty)((x, y) => chain(x, reset(y)))
 
       override def traverse_[A, B](as: => Iterable[A])(f: A => F[B]): F[Unit] =
         delay {
@@ -192,7 +225,7 @@ object Effect extends EffectFallbacks {
             runSync(fa)
         }
 
-      override def handleError[A, AA >: A](fa: F[A])(f: Throwable => F[AA]): F[AA] =
+      override def handleError[A, AA >: A](fa: => F[A])(f: Throwable => F[AA]): F[AA] =
         delay[AA](
           try
             runSync(fa)
@@ -213,11 +246,6 @@ object Effect extends EffectFallbacks {
     def fromJsPromise[A](pa: => js.Thenable[A]): F[A]
 
     def async_(onCompletion: Sync.Untyped[Unit] => Sync.Untyped[Unit]): F[Unit]
-
-    /** Wraps this callback in a `try-finally` block and runs the given callback in the `finally` clause, after the
-      * current callback completes, be it in error or success.
-      */
-    def finallyRun[A, B](fa: F[A], runFinally: F[B]): F[A]
 
     final def subst[G[_], X[_[_]]](xg: X[G])(xf: => X[F])(implicit g: Async[G]): X[F] =
       if (this eq g) xg.asInstanceOf[X[F]] else xf
@@ -252,7 +280,6 @@ object Effect extends EffectFallbacks {
 
       override def fromJsPromise[A](pa: => js.Thenable[A]): F[A] =
         async(f => () => JsUtil.runPromiseAsync(pa)(f))
-
     }
   }
 

--- a/util/src/main/scala/japgolly/scalajs/react/util/Effect.scala
+++ b/util/src/main/scala/japgolly/scalajs/react/util/Effect.scala
@@ -10,6 +10,8 @@ object Effect extends EffectFallbacks {
     /** Fire and forget, could be sync or async */
     def dispatch[A](fa: F[A]): Unit
     def dispatchFn[A](fa: => F[A]): js.Function0[Unit]
+
+    def throwException[A](t: Throwable): F[A] = delay(throw t)
   }
 
   object Dispatch {

--- a/util/src/main/scala/japgolly/scalajs/react/util/Monad.scala
+++ b/util/src/main/scala/japgolly/scalajs/react/util/Monad.scala
@@ -1,10 +1,11 @@
 package japgolly.scalajs.react.util
 
 trait Monad[F[_]] {
-  def delay  [A]   (a: => A)               : F[A]
   def pure   [A]   (a: A)                  : F[A]
   def map    [A, B](fa: F[A])(f: A => B)   : F[B]
   def flatMap[A, B](fa: F[A])(f: A => F[B]): F[B]
+
+  def tailrec[A, B](a: A)(f: A => F[Either[A, B]]): F[B]
 
   def chain[A, B](fa: F[A], fb: F[B]): F[B] =
     flatMap(fa)(_ => fb)


### PR DESCRIPTION
- Derive `cats.MonadThrow[F]` when there's an implicit `Effect.Sync[F]`.
- Derive `cats.Monoid[F[A]]` when there's an implicit `Effect.Sync[F]` and `Monoid[A]`.
- Added `throwException` to `Dispatch` typeclass.