### PR TITLE
Add react key to SVG attributes

### DIFF
--- a/library/coreGeneric/src/main/scala/japgolly/scalajs/react/vdom/SvgAttrs.scala
+++ b/library/coreGeneric/src/main/scala/japgolly/scalajs/react/vdom/SvgAttrs.scala
@@ -413,6 +413,9 @@ trait SvgAttrs {
 
   final def kerning = VdomAttr("kerning")
 
+  /** React key */
+  final val key = VdomAttr.Key
+
   final def keySplines = VdomAttr("keySplines")
 
   final def keyTimes = VdomAttr("keyTimes")


### PR DESCRIPTION
key was missing from SVG attributes, requiring users to use the HTML one, which is a bit awkward.