### PR TITLE
fix: Correct the clipPath tag

### DIFF
--- a/library/coreGeneric/src/main/scala/japgolly/scalajs/react/vdom/SvgTags.scala
+++ b/library/coreGeneric/src/main/scala/japgolly/scalajs/react/vdom/SvgTags.scala
@@ -52,7 +52,7 @@ trait SvgTags {
     * Conceptually, any parts of the drawing that lie outside of the region
     * bounded by the currently active clipping path are not drawn.
     */
-  final def clipPathTag = SvgTagOf[S.ClipPath]("clipPathTag")
+  final def clipPathTag = SvgTagOf[S.ClipPath]("clipPath")
 
   /**
     * The element allows describing the color profile used for the image.


### PR DESCRIPTION
The current version renders the `clipPathTag` tag which isn't correct.

![Screen Shot 2022-04-25 at 15 06 04](https://user-images.githubusercontent.com/4226036/165046721-b3947639-8659-4cbc-b0f9-a42f6c312bbc.png)
