### PR TITLE
Make reuse component lazy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,6 @@ on:
       - v*.*.*
 
 jobs:
-
   ci:
     runs-on: ubuntu-latest
     strategy:
@@ -18,7 +17,6 @@ jobs:
             scala: 3
     name: Scala v${{ matrix.scala }} / Java v${{ matrix.java }}
     steps:
-
       - name: Git checkout
         uses: actions/checkout@v4
         with:
@@ -37,7 +35,6 @@ jobs:
     needs: ci
     runs-on: ubuntu-latest
     steps:
-
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -46,7 +43,7 @@ jobs:
         uses: japgolly/setup-everything-scala@v3.1
 
       - name: Release
-        run: cd library && sbt ci-release
+        run: cd library && sbt -v -J-Xmx6g ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}

--- a/library/coreGeneric/src/main/scala/japgolly/scalajs/react/hooks/CustomHook.scala
+++ b/library/coreGeneric/src/main/scala/japgolly/scalajs/react/hooks/CustomHook.scala
@@ -214,7 +214,7 @@ object CustomHook {
     Reusability( (a, b) => a.reusability.test(a.value, b.value) )
 
   // Component for reuse. Must be stable.
-  private val ReuseComponent = React.memo(ScalaFnComponent[ReuseComponentProps[Any]](_.renderVdom))
+  private lazy val ReuseComponent = React.memo(ScalaFnComponent[ReuseComponentProps[Any]](_.renderVdom))
 
   def shouldComponentUpdate[D](render: D => VdomNode)(implicit r: Reusability[D]): CustomHook[() => D, VdomNode] = {
     CustomHook[() => D]


### PR DESCRIPTION
Eager initialization resulted in errors in some cases.

Also, provide more memory to build releases.