### PR TITLE
Dependency updates

### DIFF
--- a/doc/changelog/2.1.2.md
+++ b/doc/changelog/2.1.2.md
@@ -1,0 +1,24 @@
+# 2.1.2
+
+### Fixes
+
+* Components that only used the `useEffect` family of hooks were not invoking them.
+
+* Fixed the source map uri to point to the correct location
+
+### Dependencies
+
+* Upgrade sbt to 1.10.1
+* Upgrade Scala to 2.13.14 and 3.3.0
+* Upgrade Scala.js to 1.16.0
+* Upgrade microlibs to 4.1.0
+* Upgrade sbt-ci-release to 1.5.12
+* Upgrade sbt-scalafix to 0.12.1
+* Upgrade kindprojector to 0.13.3
+* Upgrade cats to 2.12.0
+* Upgrade cats-effect to 3.5.4
+* Upgrade monocle3 to 3.2.0
+* Upgrade scalajs-dom to 2.8.0
+* Upgrade sourcecode 0.4.2
+* Upgrade macrotaskExecutor to 1.1.1
+* Upgrade semanticdb to 4.9.8

--- a/doc/changelog/next.md
+++ b/doc/changelog/next.md
@@ -1,7 +1,0 @@
-# 2.2.0
-
-
-* Scala.js upgraded to 1.10.0
-* microlibs upgraded to 4.1.0
-* Scala 3 upgraded to 3.1.2
-* Fixed the source map uri to point to the correct location

--- a/downstream-tests/scalafix.sbt
+++ b/downstream-tests/scalafix.sbt
@@ -10,7 +10,7 @@ ThisBuild / scalacOptions ++= {
 
 ThisBuild / semanticdbEnabled := true
 
-ThisBuild / semanticdbVersion := "4.5.9"
+ThisBuild / semanticdbVersion := "4.9.8"
 
 ThisBuild / scalafixScalaBinaryVersion := "2.13"
 

--- a/library/callback/src/main/scala-3/japgolly/scalajs/react/callback/CallbackOption.scala
+++ b/library/callback/src/main/scala-3/japgolly/scalajs/react/callback/CallbackOption.scala
@@ -183,7 +183,7 @@ final class CallbackOption[+A](val underlyingRepr: CallbackOption.UnderlyingRepr
   def asCallback: CallbackTo[Option[A]] =
     CallbackTo lift cbfn
 
-  inline def map[B](f: A => B)(using inline ev: MapGuard[B]): CallbackOption[ev.Out] =
+  inline def map[B](f: A => B)(using ev: MapGuard[B]): CallbackOption[ev.Out] =
     unsafeMap(f)
 
   private[react] def unsafeMap[B](f: A => B): CallbackOption[B] =
@@ -192,7 +192,7 @@ final class CallbackOption[+A](val underlyingRepr: CallbackOption.UnderlyingRepr
   /**
    * Alias for `map`.
    */
-  inline def |>[B](f: A => B)(using inline ev: MapGuard[B]): CallbackOption[ev.Out] =
+  inline def |>[B](f: A => B)(using ev: MapGuard[B]): CallbackOption[ev.Out] =
     map(f)
 
   def flatMapOption[B](f: A => Option[B]): CallbackOption[B] =

--- a/library/callback/src/main/scala-3/japgolly/scalajs/react/callback/CallbackTo.scala
+++ b/library/callback/src/main/scala-3/japgolly/scalajs/react/callback/CallbackTo.scala
@@ -306,11 +306,11 @@ final class CallbackTo[+A] /*private[react]*/ (private[CallbackTo] val trampolin
   inline def runNow(): A =
     trampoline.run
 
-  inline def map[B](f: A => B)(using inline ev: MapGuard[B]): CallbackTo[ev.Out] =
+  inline def map[B](f: A => B)(using ev: MapGuard[B]): CallbackTo[ev.Out] =
     new CallbackTo(trampoline.map(f))
 
   /** Alias for `map`. */
-  inline def |>[B](inline f: A => B)(using inline ev: MapGuard[B]): CallbackTo[ev.Out] =
+  inline def |>[B](inline f: A => B)(using ev: MapGuard[B]): CallbackTo[ev.Out] =
     map(f)
 
   inline def flatMap[B](f: A => CallbackTo[B]): CallbackTo[B] =
@@ -589,7 +589,7 @@ final class CallbackTo[+A] /*private[react]*/ (private[CallbackTo] val trampolin
 
 
   /** Convenience-method to run additional code after this callback. */
-  inline def thenRun[B](inline runNext: B)(using inline ev: MapGuard[B]): CallbackTo[ev.Out] =
+  inline def thenRun[B](inline runNext: B)(using ev: MapGuard[B]): CallbackTo[ev.Out] =
     this >> CallbackTo(runNext)
 
   /** Convenience-method to run additional code before this callback. */

--- a/library/coreGeneric/src/main/scala-3/japgolly/scalajs/react/ReusabilityMacros.scala
+++ b/library/coreGeneric/src/main/scala-3/japgolly/scalajs/react/ReusabilityMacros.scala
@@ -188,7 +188,7 @@ object ReusabilityMacros {
       var set = Set.empty[String]
       for (e <- es)
         if set.contains(e)
-        then quotes.reflect.report.throwError(s"Duplicate field specified: \"$e\"")
+        then quotes.reflect.report.errorAndAbort(s"Duplicate field specified: \"$e\"")
         else set += e
       new FieldExclusions(set)
     }
@@ -219,7 +219,7 @@ object ReusabilityMacros {
           then s"Specified field ${fs.head} doesn't exist."
           else s"Specified fields ${fs.mkString(", ")} don't exist."
         val err = s"Failed to derive a Reusability instance for ${Type.show[A]}: $subErr"
-        quotes.reflect.report.throwError(err)
+        quotes.reflect.report.errorAndAbort(err)
       }
   }
 

--- a/library/coreGeneric/src/main/scala-3/japgolly/scalajs/react/component/builder/ComponentBuilderMacros.scala
+++ b/library/coreGeneric/src/main/scala-3/japgolly/scalajs/react/component/builder/ComponentBuilderMacros.scala
@@ -3,7 +3,9 @@ package japgolly.scalajs.react.component.builder
 import japgolly.microlibs.compiletime.MacroEnv.*
 import japgolly.scalajs.react.{Children, PropsChildren}
 import japgolly.scalajs.react.component.builder.Lifecycle.RenderScope
+import japgolly.scalajs.react.component.Generic
 import japgolly.scalajs.react.component.Scala.BackendScope
+import japgolly.scalajs.react.util.DefaultEffects.{Async => DefaultA, Sync => DefaultS}
 import japgolly.scalajs.react.vdom.VdomNode
 import scala.language.`3.0`
 import scala.quoted.*
@@ -36,7 +38,7 @@ object ComponentBuilderMacros {
       t => monoName(t) == name
     }
 
-    def lambdaBody(input: Expr[Input]): Expr[B] = {
+    def lambdaBody(input: Expr[BackendScope[P, S]]): Expr[B] = {
       MacroUtils.NewInstance.of[B](
         findTermArg = Some { (valDef, fail) =>
           import quotes.reflect.*

--- a/library/project/Dependencies.scala
+++ b/library/project/Dependencies.scala
@@ -9,22 +9,22 @@ object Dependencies {
   object Ver {
 
     // Externally observable
-    val cats                  = "2.7.0"
-    val catsEffect            = "3.3.11"
+    val cats                  = "2.12.0"
+    val catsEffect            = "3.5.4"
     val microlibs             = "4.1.0"
     val monocle2              = "2.1.0"
-    val monocle3              = "3.1.0"
-    val scala2                = "2.13.8"
-    val scala3                = "3.1.2"
-    val scalaJsDom            = "2.0.0"
-    val sourcecode            = "0.2.8"
+    val monocle3              = "3.2.0"
+    val scala2                = "2.13.14"
+    val scala3                = "3.3.0"
+    val scalaJsDom            = "2.8.0"
+    val sourcecode            = "0.4.2"
 
     // Internal
     val betterMonadicFor      = "0.3.1"
     val catsTestkitScalaTest  = "2.1.5"
     val disciplineScalaTest   = "2.1.5"
-    val kindProjector         = "0.13.2"
-    val macrotaskExecutor     = "1.0.0"
+    val kindProjector         = "0.13.3"
+    val macrotaskExecutor     = "1.1.1"
     val nyaya                 = "1.0.0"
     val reactJs               = "17.0.2"
     val scalaJsJavaTime       = "1.0.0"

--- a/library/project/build.properties
+++ b/library/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.2
+sbt.version=1.10.1

--- a/library/project/plugins.sbt
+++ b/library/project/plugins.sbt
@@ -2,7 +2,7 @@ libraryDependencies ++= Seq(
   "org.scala-js" %% "scalajs-env-jsdom-nodejs" % "1.1.0",
   "org.scala-js" %% "scalajs-env-selenium"     % "1.1.1")
 
-addSbtPlugin("ch.epfl.scala"  % "sbt-scalafix"       % "0.10.1")
-addSbtPlugin("com.github.sbt" % "sbt-ci-release"     % "1.5.10")
+addSbtPlugin("ch.epfl.scala"  % "sbt-scalafix"       % "0.12.1")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release"     % "1.5.12")
 addSbtPlugin("org.scala-js"   % "sbt-jsdependencies" % "1.0.2")
-addSbtPlugin("org.scala-js"   % "sbt-scalajs"        % "1.10.0")
+addSbtPlugin("org.scala-js"   % "sbt-scalajs"        % "1.16.0")

--- a/library/scalafix.sbt
+++ b/library/scalafix.sbt
@@ -8,10 +8,4 @@ ThisBuild / scalacOptions ++= {
 ThisBuild / semanticdbEnabled := true
 
 // NOTE: Upgrade downstream-tests/scalafix.sbt too!
-ThisBuild / semanticdbVersion := "4.5.9"
-
-ThisBuild / scalafixScalaBinaryVersion := "2.13"
-
-ThisBuild / scalafixDependencies ++= Seq(
-  "com.github.liancheng" %% "organize-imports" % "0.6.0"
-)
+ThisBuild / semanticdbVersion := "4.9.8"

--- a/library/tests/src/test/scala/japgolly/scalajs/react/core/ScalaComponentTest.scala
+++ b/library/tests/src/test/scala/japgolly/scalajs/react/core/ScalaComponentTest.scala
@@ -169,7 +169,8 @@ object ScalaComponentPTest extends TestSuite {
 
         assertEq("willUnmountCount", willUnmountCount, 0)
         mounted = Comp(null).renderIntoDOM(mountNode)
-        assertOuterHTMLMatches(el(), "<div>Error: Cannot read propert(y|ies) of null.*</div>")
+        // Error message varies between development and production modes
+        assertOuterHTMLMatches(el(), "<div>(?:Error: Cannot read propert(y|ies) of null.*|Error: java\\.lang\\.NullPointerException)</div>")
         assertEq("willUnmountCount", willUnmountCount, 1)
         mounted.withEffectsPure.getDOMNode
       }


### PR DESCRIPTION
I can't upgrade Scala 3 past 3.3.0. Starting with 3.3.1, the backend macro produces an error that I haven't been able to figure out how to fix.