### PR TITLE
Wrap router actions in startTransition

### DIFF
--- a/library/extra/src/main/scala/japgolly/scalajs/react/extra/router/Router.scala
+++ b/library/extra/src/main/scala/japgolly/scalajs/react/extra/router/Router.scala
@@ -6,6 +6,7 @@ import japgolly.scalajs.react.util.DefaultEffects
 import japgolly.scalajs.react.util.Effect.Sync
 import japgolly.scalajs.react.util.Util.identityFn
 import japgolly.scalajs.react.vdom.VdomElement
+import japgolly.scalajs.react.React.startTransition
 import org.scalajs.dom
 import scala.scalajs.js
 
@@ -50,7 +51,7 @@ object RouterWithProps {
       .render                 ($ => lgc.render($.state, $.props))
       .componentDidMount      ($ => cfg.postRenderFn(None, $.state.page, $.props))
       .componentDidUpdate     (i => cfg.postRenderFn(Some(i.prevState.page), i.currentState.page, i.currentProps))
-      .configure              (ListenableF.listenToUnit(_ => lgc, $ => F.flatMap(lgc.syncToWindowUrl)(s => F.transSync($.setState(s)))))
+      .configure              (ListenableF.listenToUnit(_ => lgc, $ => F.flatMap(lgc.syncToWindowUrl)(s => F.transSync(startTransition($.setState(s))))))
       .configure              (EL.install_("popstate", lgc.ctl.refresh, dom.window))
       .configureWhen(isIE11())(EL.install_("hashchange", lgc.ctl.refresh, dom.window))
   }


### PR DESCRIPTION
This wraps the router state actions in [startTransition](https://react.dev/reference/react/useTransition#starttransition). This allows router updates to be non-blocking. React recommends all router updates to be wrapped in a transition.

I.e. if you click on 1 page, you can immediately navigate to another page without waiting for the first page to finish rendering.

~~I've wrapped 2 actions in `startTransition`, these made the most sense to me, but I'm not sure if both of them are necessary. The code is a bit complex 😅~~
