### PR TITLE
Allow custom route parsers

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+use flake
+layout node
+eval "$shellHook" 

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ metals.sbt
 node_modules/
 package-lock.json
 target
+.direnv/

--- a/downstream-tests/scalafix.sbt
+++ b/downstream-tests/scalafix.sbt
@@ -10,7 +10,7 @@ ThisBuild / scalacOptions ++= {
 
 ThisBuild / semanticdbEnabled := true
 
-ThisBuild / semanticdbVersion := "4.5.9"
+ThisBuild / semanticdbVersion := "4.12.0"
 
 ThisBuild / scalafixScalaBinaryVersion := "2.13"
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,109 @@
+{
+  "nodes": {
+    "devshell": {
+      "inputs": {
+        "nixpkgs": [
+          "typelevel-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1728330715,
+        "narHash": "sha256-xRJ2nPOXb//u1jaBnDP56M7v5ldavjbtR6lfGqSvcKg=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "dd6b80932022cea34a019e2bb32f6fa9e494dfef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1733376361,
+        "narHash": "sha256-aLJxoTDDSqB+/3orsulE6/qdlX6MzDLIITLZqdgMpqo=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "929116e316068c7318c54eb4d827f7d9756d5e9c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": [
+          "typelevel-nix",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "typelevel-nix",
+          "nixpkgs"
+        ],
+        "typelevel-nix": "typelevel-nix"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "typelevel-nix": {
+      "inputs": {
+        "devshell": "devshell",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1733783241,
+        "narHash": "sha256-nDM0W3EhiVJDFPCInPzJ9+QUyyjMTZhlTK8JGN7vfJQ=",
+        "owner": "typelevel",
+        "repo": "typelevel-nix",
+        "rev": "a4a46f0b1b94e150a1dda0a8f0f013696d9299fd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "typelevel",
+        "repo": "typelevel-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,43 @@
+{
+  inputs = {
+    typelevel-nix.url = "github:typelevel/typelevel-nix";
+    nixpkgs.follows = "typelevel-nix/nixpkgs";
+    flake-utils.follows = "typelevel-nix/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, typelevel-nix }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs-x86_64 = import nixpkgs { system = "x86_64-darwin"; };
+        scala-cli-overlay = final: prev: { scala-cli = pkgs-x86_64.scala-cli; };
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ typelevel-nix.overlays.default scala-cli-overlay];
+        };
+      in
+      {
+        devShell = pkgs.devshell.mkShell {
+          imports = [ typelevel-nix.typelevelShell ];
+          packages = [
+            pkgs.nodePackages.typescript-language-server
+            pkgs.nodePackages.vscode-langservers-extracted
+            pkgs.nodePackages.prettier
+            pkgs.nodePackages.typescript
+            pkgs.nodePackages.graphqurl
+            pkgs.hasura-cli
+          ];
+          typelevelShell = {
+            nodejs.enable = true;
+            jdk.package = pkgs.jdk21;
+          };
+          env = [
+            {
+              name = "NODE_OPTIONS";
+              value = "--max-old-space-size=8192";
+            }
+          ];
+        };
+      }
+
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,7 @@
           ];
           typelevelShell = {
             nodejs.enable = true;
-            jdk.package = pkgs.jdk21;
+            jdk.package = pkgs.jdk11;
           };
           env = [
             {

--- a/library/callback/src/main/scala-3/japgolly/scalajs/react/callback/CallbackOption.scala
+++ b/library/callback/src/main/scala-3/japgolly/scalajs/react/callback/CallbackOption.scala
@@ -183,7 +183,7 @@ final class CallbackOption[+A](val underlyingRepr: CallbackOption.UnderlyingRepr
   def asCallback: CallbackTo[Option[A]] =
     CallbackTo lift cbfn
 
-  inline def map[B](f: A => B)(using inline ev: MapGuard[B]): CallbackOption[ev.Out] =
+  inline def map[B](f: A => B)(using ev: MapGuard[B]): CallbackOption[ev.Out] =
     unsafeMap(f)
 
   private[react] def unsafeMap[B](f: A => B): CallbackOption[B] =
@@ -192,7 +192,7 @@ final class CallbackOption[+A](val underlyingRepr: CallbackOption.UnderlyingRepr
   /**
    * Alias for `map`.
    */
-  inline def |>[B](f: A => B)(using inline ev: MapGuard[B]): CallbackOption[ev.Out] =
+  inline def |>[B](f: A => B)(using ev: MapGuard[B]): CallbackOption[ev.Out] =
     map(f)
 
   def flatMapOption[B](f: A => Option[B]): CallbackOption[B] =

--- a/library/callback/src/main/scala-3/japgolly/scalajs/react/callback/CallbackTo.scala
+++ b/library/callback/src/main/scala-3/japgolly/scalajs/react/callback/CallbackTo.scala
@@ -306,11 +306,11 @@ final class CallbackTo[+A] /*private[react]*/ (private[CallbackTo] val trampolin
   inline def runNow(): A =
     trampoline.run
 
-  inline def map[B](f: A => B)(using inline ev: MapGuard[B]): CallbackTo[ev.Out] =
+  inline def map[B](f: A => B)(using ev: MapGuard[B]): CallbackTo[ev.Out] =
     new CallbackTo(trampoline.map(f))
 
   /** Alias for `map`. */
-  inline def |>[B](inline f: A => B)(using inline ev: MapGuard[B]): CallbackTo[ev.Out] =
+  inline def |>[B](inline f: A => B)(using ev: MapGuard[B]): CallbackTo[ev.Out] =
     map(f)
 
   inline def flatMap[B](f: A => CallbackTo[B]): CallbackTo[B] =
@@ -589,7 +589,7 @@ final class CallbackTo[+A] /*private[react]*/ (private[CallbackTo] val trampolin
 
 
   /** Convenience-method to run additional code after this callback. */
-  inline def thenRun[B](inline runNext: B)(using inline ev: MapGuard[B]): CallbackTo[ev.Out] =
+  inline def thenRun[B](inline runNext: B)(using ev: MapGuard[B]): CallbackTo[ev.Out] =
     this >> CallbackTo(runNext)
 
   /** Convenience-method to run additional code before this callback. */

--- a/library/extra/src/main/scala/japgolly/scalajs/react/extra/router/Dsl.scala
+++ b/library/extra/src/main/scala/japgolly/scalajs/react/extra/router/Dsl.scala
@@ -191,6 +191,9 @@ object StaticDsl {
       r.xmap(_ getOrElse default)(a => if (default == a) None else Some(a))
   }
 
+  /**
+   * Translates a `Path` into an instance of model `A` and vice versa.
+   */
   trait Route[A] extends RouteCommon[Route, A] {
     def parse(path: Path): Option[A]
     def pathFor(a: A): Path

--- a/library/project/Dependencies.scala
+++ b/library/project/Dependencies.scala
@@ -14,7 +14,7 @@ object Dependencies {
     val microlibs             = "4.1.0"
     val monocle2              = "2.1.0"
     val monocle3              = "3.2.0"
-    val scala2                = "2.13.14"
+    val scala2                = "2.13.15"
     val scala3                = "3.3.0"
     val scalaJsDom            = "2.8.0"
     val sourcecode            = "0.4.2"

--- a/library/project/Dependencies.scala
+++ b/library/project/Dependencies.scala
@@ -9,23 +9,23 @@ object Dependencies {
   object Ver {
 
     // Externally observable
-    val cats                  = "2.7.0"
-    val catsEffect            = "3.3.11"
-    val microlibs             = "4.2.1"
+    val cats                  = "2.12.0"
+    val catsEffect            = "3.5.4"
+    val microlibs             = "4.1.0"
     val monocle2              = "2.1.0"
-    val monocle3              = "3.1.0"
-    val scala2                = "2.13.8"
-    val scala3                = "3.1.2"
-    val scalaJsDom            = "2.0.0"
-    val sourcecode            = "0.2.8"
+    val monocle3              = "3.2.0"
+    val scala2                = "2.13.14"
+    val scala3                = "3.3.0"
+    val scalaJsDom            = "2.8.0"
+    val sourcecode            = "0.4.2"
 
     // Internal
     val betterMonadicFor      = "0.3.1"
     val catsTestkitScalaTest  = "2.1.5"
     val disciplineScalaTest   = "2.1.5"
     val fastTextEncoding      = "1.0.6"
-    val kindProjector         = "0.13.2"
-    val macrotaskExecutor     = "1.0.0"
+    val kindProjector         = "0.13.3"
+    val macrotaskExecutor     = "1.1.1"
     val nyaya                 = "1.0.0"
     val reactJs               = "18.2.0"
     val scalaJsJavaTime       = "1.0.0"

--- a/library/project/plugins.sbt
+++ b/library/project/plugins.sbt
@@ -2,7 +2,7 @@ libraryDependencies ++= Seq(
   "org.scala-js" %% "scalajs-env-jsdom-nodejs" % "1.1.0",
   "org.scala-js" %% "scalajs-env-selenium"     % "1.1.1")
 
-addSbtPlugin("ch.epfl.scala"  % "sbt-scalafix"       % "0.10.1")
-addSbtPlugin("com.github.sbt" % "sbt-ci-release"     % "1.5.10")
+addSbtPlugin("ch.epfl.scala"  % "sbt-scalafix"       % "0.12.1")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release"     % "1.5.12")
 addSbtPlugin("org.scala-js"   % "sbt-jsdependencies" % "1.0.2")
 addSbtPlugin("org.scala-js"   % "sbt-scalajs"        % "1.16.0")

--- a/library/scalafix.sbt
+++ b/library/scalafix.sbt
@@ -8,4 +8,4 @@ ThisBuild / scalacOptions ++= {
 ThisBuild / semanticdbEnabled := true
 
 // NOTE: Upgrade downstream-tests/scalafix.sbt too!
-ThisBuild / semanticdbVersion := "4.5.9"
+ThisBuild / semanticdbVersion := "4.9.8"

--- a/library/scalafix.sbt
+++ b/library/scalafix.sbt
@@ -8,4 +8,4 @@ ThisBuild / scalacOptions ++= {
 ThisBuild / semanticdbEnabled := true
 
 // NOTE: Upgrade downstream-tests/scalafix.sbt too!
-ThisBuild / semanticdbVersion := "4.9.8"
+ThisBuild / semanticdbVersion := "4.12.0"


### PR DESCRIPTION
This PR allows users to define custom `Route`s which turn `Path`s into pages and viceversa, without requiring them to be build via the DSL. Of course, the old DSL still works.

Also: add flake.nix, update dependencies.