### PR TITLE
Implement missing React 18 hooks, useCallback accepts non-unit afunctions

### DIFF
--- a/library/coreGeneric/src/main/scala/japgolly/scalajs/react/hooks/Api.scala
+++ b/library/coreGeneric/src/main/scala/japgolly/scalajs/react/hooks/Api.scala
@@ -6,6 +6,7 @@ import japgolly.scalajs.react.feature.Context
 import japgolly.scalajs.react.hooks.Hooks._
 import japgolly.scalajs.react.internal.Box
 import japgolly.scalajs.react.util.DefaultEffects
+import japgolly.scalajs.react.util.Effect.Sync
 import japgolly.scalajs.react.util.Util.identityFn
 import japgolly.scalajs.react.vdom.{TopNode, VdomNode}
 import japgolly.scalajs.react.{Children, CtorType, Ref, Reusability, Reusable}
@@ -342,6 +343,93 @@ object Api {
     final def useLayoutEffectWithDepsBy[D, A](deps: Ctx => D)(effect: Ctx => D => A)(implicit a: UseEffectArg[A], r: Reusability[D], step: Step): step.Self =
       customBy(ctx => ReusableEffect.useLayoutEffect(deps(ctx))(effect(ctx)))
 
+    //************
+
+    /** The signature is identical to [[useEffect]], but it fires synchronously after all DOM mutations. Use this to
+      * read Insertion from the DOM and synchronously re-render. Updates scheduled inside useInsertionEffect will be flushed
+      * synchronously, before the browser has a chance to paint.
+      *
+      * Prefer the standard [[useEffect]] when possible to avoid blocking visual updates.
+      *
+      * If you'd only like to execute the effect when your component is mounted, then use [[useInsertionEffectOnMount]].
+      * If you'd only like to execute the effect when certain values have changed, provide those certain values as
+      * the second argument.
+      *
+      * @see https://react.dev/reference/react/useInsertionEffect#useinsertioneffect
+      */
+    final def useInsertionEffect[A](effect: A)(implicit a: UseEffectArg[A], step: Step): step.Self =
+      useInsertionEffectBy(_ => effect)
+
+    /** The signature is identical to [[useEffect]], but it fires synchronously after all DOM mutations. Use this to
+      * read Insertion from the DOM and synchronously re-render. Updates scheduled inside useInsertionEffect will be flushed
+      * synchronously, before the browser has a chance to paint.
+      *
+      * Prefer the standard [[useEffect]] when possible to avoid blocking visual updates.
+      *
+      * If you'd only like to execute the effect when your component is mounted, then use [[useInsertionEffectOnMount]].
+      * If you'd only like to execute the effect when certain values have changed, provide those certain values as
+      * the second argument.
+      *
+      * @see https://react.dev/reference/react/useInsertionEffect#useinsertioneffect
+      */
+    final def useInsertionEffectBy[A](init: Ctx => A)(implicit a: UseEffectArg[A], step: Step): step.Self =
+      self(ctx => UseEffect.unsafeCreateInsertion(init(ctx)))
+
+    /** The signature is identical to [[useEffect]], but it fires synchronously after all DOM mutations. Use this to
+      * read Insertion from the DOM and synchronously re-render. Updates scheduled inside useInsertionEffect will be flushed
+      * synchronously, before the browser has a chance to paint.
+      *
+      * Prefer the standard [[useEffect]] when possible to avoid blocking visual updates.
+      *
+      * This will only execute the effect when your component is mounted.
+      *
+      * @see https://react.dev/reference/react/useInsertionEffect#useinsertioneffect
+      */
+    final def useInsertionEffectOnMount[A](effect: A)(implicit a: UseEffectArg[A], step: Step): step.Self =
+      useInsertionEffectOnMountBy(_ => effect)
+
+    /** The signature is identical to [[useEffect]], but it fires synchronously after all DOM mutations. Use this to
+      * read Insertion from the DOM and synchronously re-render. Updates scheduled inside useInsertionEffect will be flushed
+      * synchronously, before the browser has a chance to paint.
+      *
+      * Prefer the standard [[useEffect]] when possible to avoid blocking visual updates.
+      *
+      * This will only execute the effect when your component is mounted.
+      *
+      * @see https://react.dev/reference/react/useInsertionEffect#useinsertioneffect
+      */
+    final def useInsertionEffectOnMountBy[A](effect: Ctx => A)(implicit a: UseEffectArg[A], step: Step): step.Self =
+      self(ctx => UseEffect.unsafeCreateInsertionOnMount(effect(ctx)))
+
+    /** The signature is identical to [[useEffect]], but it fires synchronously after all DOM mutations. Use this to
+      * read Insertion from the DOM and synchronously re-render. Updates scheduled inside useInsertionEffect will be flushed
+      * synchronously, before the browser has a chance to paint.
+      *
+      * Prefer the standard [[useEffect]] when possible to avoid blocking visual updates.
+      *
+      * This will only execute the effect when values in the second argument, change.
+      *
+      * @see https://react.dev/reference/react/useInsertionEffect#useinsertioneffect
+      */
+    final def useInsertionEffectWithDeps[D, A](deps: => D)(effect: D => A)(implicit a: UseEffectArg[A], r: Reusability[D], step: Step): step.Self =
+      custom(ReusableEffect.useInsertionEffect(deps)(effect))
+
+    /** The signature is identical to [[useEffect]], but it fires synchronously after all DOM mutations. Use this to
+      * read Insertion from the DOM and synchronously re-render. Updates scheduled inside useInsertionEffect will be flushed
+      * synchronously, before the browser has a chance to paint.
+      *
+      * Prefer the standard [[useEffect]] when possible to avoid blocking visual updates.
+      *
+      * This will only execute the effect when values in the second argument, change.
+      *
+      * @see https://react.dev/reference/react/useInsertionEffect#useinsertioneffect
+      */
+    final def useInsertionEffectWithDepsBy[D, A](deps: Ctx => D)(effect: Ctx => D => A)(implicit a: UseEffectArg[A], r: Reusability[D], step: Step): step.Self =
+      customBy(ctx => ReusableEffect.useInsertionEffect(deps(ctx))(effect(ctx)))
+
+
+    //************
+
     /** Returns a memoized value.
       *
       * Pass a “create” function and any dependencies. useMemo will only recompute the memoized value when one
@@ -478,7 +566,7 @@ object Api {
     final def useStateWithReuseBy[S: ClassTag: Reusability](initialState: Ctx => S)(implicit step: Step): step.Next[UseStateWithReuse[S]] =
       next(ctx => UseStateWithReuse.unsafeCreate(initialState(ctx)))
 
-    /** `useId` is a React Hook for generating unique IDs that can be passed to accessibility attributes.
+    /** Generates unique IDs that can be passed to accessibility attributes.
       * 
       * @see https://react.dev/reference/react/useId
       */
@@ -496,6 +584,41 @@ object Api {
       */
     final def useTransition(implicit step: Step): step.Next[UseTransition] =
       customBy(_ => UseTransition())
+
+    /**
+      * Lets you subscribe to an external store.
+      *
+      * @see
+      *   {@link https://react.dev/reference/react/useSyncExternalStore}
+      */
+    @inline final def useSyncExternalStore[F[_], A](subscribe: F[Unit] => F[F[Unit]], getSnapshot: F[A])(implicit F: Sync[F], step: Step): step.Next[A] =
+      useSyncExternalStore(subscribe, getSnapshot, js.undefined)
+
+    /**
+      * Lets you subscribe to an external store.
+      *
+      * @see
+      *   {@link https://react.dev/reference/react/useSyncExternalStore}
+      */
+    final def useSyncExternalStore[F[_], A](subscribe: F[Unit] => F[F[Unit]], getSnapshot: F[A], getServerSnapshot: js.UndefOr[F[A]])(implicit F: Sync[F], step: Step): step.Next[A] =
+      customBy(_ => UseSyncExternalStore(subscribe, getSnapshot, getServerSnapshot))
+
+    /**
+      * Lets you subscribe to an external store.
+      *
+      * @see
+      *   {@link https://react.dev/reference/react/useSyncExternalStore}
+      */
+    @inline final def useSyncExternalStoreBy[F[_], A](subscribe: Ctx => F[Unit] => F[F[Unit]], getSnapshot: Ctx => F[A])(implicit F: Sync[F], step: Step): step.Next[A] =
+      useSyncExternalStoreBy(subscribe, getSnapshot, js.undefined)
+    /**
+      * Lets you subscribe to an external store.
+      *
+      * @see
+      *   {@link https://react.dev/reference/react/useSyncExternalStore}
+      */
+    final def useSyncExternalStoreBy[F[_], A](subscribe: Ctx => F[Unit] => F[F[Unit]], getSnapshot: Ctx => F[A], getServerSnapshot: js.UndefOr[Ctx => F[A]])(implicit F: Sync[F], step: Step): step.Next[A] =
+      customBy(ctx => UseSyncExternalStore(subscribe(ctx), getSnapshot(ctx), getServerSnapshot.map(_(ctx))))
   }
 
   // ===================================================================================================================
@@ -693,6 +816,23 @@ object Api {
       */
     final def useStateWithReuseBy[S: ClassTag: Reusability](initialState: CtxFn[S])(implicit step: Step): step.Next[UseStateWithReuse[S]] =
       useStateWithReuseBy(step.squash(initialState)(_))
+
+    /**
+      * Lets you subscribe to an external store.
+      *
+      * @see
+      *   {@link https://react.dev/reference/react/useSyncExternalStore}
+      */
+    @inline final def useSyncExternalStoreBy[F[_], A](subscribe: CtxFn[F[Unit] => F[F[Unit]]], getSnapshot: CtxFn[F[A]])(implicit F: Sync[F], step: Step): step.Next[A] =
+      useSyncExternalStoreBy(subscribe, getSnapshot, js.undefined)
+    /**
+      * Lets you subscribe to an external store.
+      *
+      * @see
+      *   {@link https://react.dev/reference/react/useSyncExternalStore}
+      */
+    final def useSyncExternalStoreBy[F[_], A](subscribe: CtxFn[F[Unit] => F[F[Unit]]], getSnapshot: CtxFn[F[A]], getServerSnapshot: js.UndefOr[CtxFn[F[A]]])(implicit F: Sync[F], step: Step): step.Next[A] =
+      useSyncExternalStoreBy(ctx => step.squash(subscribe)(ctx), ctx => step.squash(getSnapshot)(ctx), getServerSnapshot.map(f => ctx => step.squash(f)(ctx)))
   }
 
   // ===================================================================================================================

--- a/library/coreGeneric/src/main/scala/japgolly/scalajs/react/hooks/Api.scala
+++ b/library/coreGeneric/src/main/scala/japgolly/scalajs/react/hooks/Api.scala
@@ -196,8 +196,7 @@ object Api {
       *
       * By default, effects run after every completed render.
       * If you'd only like to execute the effect when your component is mounted, then use [[useEffectOnMount]].
-      * If you'd only like to execute the effect when certain values have changed, provide those certain values as
-      * a first argument.
+      * If you'd only like to execute the effect when certain values have changed, then use [[useEffectWithDeps]].
       *
       * @see https://reactjs.org/docs/hooks-reference.html#useeffect
       */
@@ -209,8 +208,7 @@ object Api {
       *
       * By default, effects run after every completed render.
       * If you'd only like to execute the effect when your component is mounted, then use [[useEffectOnMount]].
-      * If you'd only like to execute the effect when certain values have changed, provide those certain values as
-      * a first argument.
+      * If you'd only like to execute the effect when certain values have changed, then use [[useEffectWithDeps]].
       *
       * @see https://reactjs.org/docs/hooks-reference.html#useeffect
       */
@@ -240,7 +238,7 @@ object Api {
     /** The callback passed to useEffect will run after the render is committed to the screen. Think of effects as an
       * escape hatch from React’s purely functional world into the imperative world.
       *
-      * This will only execute the effect when values in a first argument, change.
+      * This will only execute the effect when values in the first argument change.
       *
       * @see https://reactjs.org/docs/hooks-reference.html#useeffect
       */
@@ -250,7 +248,7 @@ object Api {
     /** The callback passed to useEffect will run after the render is committed to the screen. Think of effects as an
       * escape hatch from React’s purely functional world into the imperative world.
       *
-      * This will only execute the effect when values in a first argument, change.
+      * This will only execute the effect when values in the first argument change.
       *
       * @see https://reactjs.org/docs/hooks-reference.html#useeffect
       */
@@ -268,8 +266,7 @@ object Api {
       * Prefer the standard [[useEffect]] when possible to avoid blocking visual updates.
       *
       * If you'd only like to execute the effect when your component is mounted, then use [[useLayoutEffectOnMount]].
-      * If you'd only like to execute the effect when certain values have changed, provide those certain values as
-      * a first argument.
+      * If you'd only like to execute the effect when certain values have changed, then use [[useLayoutEffectWithDeps]].
       *
       * @see https://reactjs.org/docs/hooks-reference.html#useLayoutEffect
       */
@@ -283,8 +280,7 @@ object Api {
       * Prefer the standard [[useEffect]] when possible to avoid blocking visual updates.
       *
       * If you'd only like to execute the effect when your component is mounted, then use [[useLayoutEffectOnMount]].
-      * If you'd only like to execute the effect when certain values have changed, provide those certain values as
-      * a first argument.
+      * If you'd only like to execute the effect when certain values have changed, then use [[useLayoutEffectWithDeps]].
       *
       * @see https://reactjs.org/docs/hooks-reference.html#useLayoutEffect
       */
@@ -323,7 +319,7 @@ object Api {
       *
       * Prefer the standard [[useEffect]] when possible to avoid blocking visual updates.
       *
-      * This will only execute the effect when values in a first argument, change.
+      * This will only execute the effect when values in the first argument change.
       *
       * @see https://reactjs.org/docs/hooks-reference.html#useLayoutEffect
       */
@@ -336,7 +332,7 @@ object Api {
       *
       * Prefer the standard [[useEffect]] when possible to avoid blocking visual updates.
       *
-      * This will only execute the effect when values in a first argument, change.
+      * This will only execute the effect when values in the first argument change.
       *
       * @see https://reactjs.org/docs/hooks-reference.html#useLayoutEffect
       */
@@ -350,8 +346,7 @@ object Api {
       * Prefer the standard [[useEffect]] when possible to avoid blocking visual updates.
       *
       * If you'd only like to execute the effect when your component is mounted, then use [[useInsertionEffectOnMount]].
-      * If you'd only like to execute the effect when certain values have changed, provide those certain values as
-      * the first argument.
+      * If you'd only like to execute the effect when certain values have changed, then use [[useInsertionEffectWithDeps]].
       *
       * @see https://react.dev/reference/react/useInsertionEffect#useInsertionEffect
       */
@@ -365,8 +360,7 @@ object Api {
       * Prefer the standard [[useEffect]] when possible to avoid blocking visual updates.
       *
       * If you'd only like to execute the effect when your component is mounted, then use [[useInsertionEffectOnMount]].
-      * If you'd only like to execute the effect when certain values have changed, provide those certain values as
-      * the first argument.
+      * If you'd only like to execute the effect when certain values have changed, then use [[useInsertionEffectWithDeps]].
       *
       * @see https://react.dev/reference/react/useInsertionEffect#useInsertionEffect
       */
@@ -379,9 +373,7 @@ object Api {
       *
       * Prefer the standard [[useEffect]] when possible to avoid blocking visual updates.
       *
-      * If you'd only like to execute the effect when your component is mounted, then use [[useInsertionEffectOnMount]].
-      * If you'd only like to execute the effect when certain values have changed, provide those certain values as
-      * the first argument.
+      * This will only execute the effect when your component is mounted.
       *
       * @see https://react.dev/reference/react/useInsertionEffect#useInsertionEffect
       */
@@ -394,9 +386,7 @@ object Api {
       *
       * Prefer the standard [[useEffect]] when possible to avoid blocking visual updates.
       *
-      * If you'd only like to execute the effect when your component is mounted, then use [[useInsertionEffectOnMount]].
-      * If you'd only like to execute the effect when certain values have changed, provide those certain values as
-      * the first argument.
+      * This will only execute the effect when your component is mounted.
       *
       * @see https://react.dev/reference/react/useInsertionEffect#useInsertionEffect
       */
@@ -409,9 +399,7 @@ object Api {
       *
       * Prefer the standard [[useEffect]] when possible to avoid blocking visual updates.
       *
-      * If you'd only like to execute the effect when your component is mounted, then use [[useInsertionEffectOnMount]].
-      * If you'd only like to execute the effect when certain values have changed, provide those certain values as
-      * the first argument.
+      * This will only execute the effect when values in the first argument change.
       *
       * @see https://react.dev/reference/react/useInsertionEffect#useInsertionEffect
       */
@@ -424,9 +412,7 @@ object Api {
       *
       * Prefer the standard [[useEffect]] when possible to avoid blocking visual updates.
       *
-      * If you'd only like to execute the effect when your component is mounted, then use [[useInsertionEffectOnMount]].
-      * If you'd only like to execute the effect when certain values have changed, provide those certain values as
-      * the first argument.
+      * This will only execute the effect when values in the first argument change.
       *
       * @see https://react.dev/reference/react/useInsertionEffect#useInsertionEffect
       */
@@ -720,8 +706,7 @@ object Api {
       *
       * By default, effects run after every completed render.
       * If you'd only like to execute the effect when your component is mounted, then use [[useEffectOnMount]].
-      * If you'd only like to execute the effect when certain values have changed, provide those certain values as
-      * a first argument.
+      * If you'd only like to execute the effect when certain values have changed, then use [[useEffectWithDeps]].
       *
       * @see https://reactjs.org/docs/hooks-reference.html#useeffect
       */
@@ -731,7 +716,7 @@ object Api {
     /** The callback passed to useEffect will run after the render is committed to the screen. Think of effects as an
       * escape hatch from React’s purely functional world into the imperative world.
       *
-      * This will only execute the effect when values in a first argument, change.
+      * This will only execute the effect when values in the first argument change.
       *
       * @see https://reactjs.org/docs/hooks-reference.html#useeffect
       */
@@ -755,8 +740,7 @@ object Api {
       * Prefer the standard [[useEffect]] when possible to avoid blocking visual updates.
       *
       * If you'd only like to execute the effect when your component is mounted, then use [[useLayoutEffectOnMount]].
-      * If you'd only like to execute the effect when certain values have changed, provide those certain values as
-      * a first argument.
+      * If you'd only like to execute the effect when certain values have changed, then use [[useLayoutEffectWithDeps]].
       *
       * @see https://reactjs.org/docs/hooks-reference.html#useLayoutEffect
       */
@@ -769,7 +753,7 @@ object Api {
       *
       * Prefer the standard [[useEffect]] when possible to avoid blocking visual updates.
       *
-      * This will only execute the effect when values in a first argument, change.
+      * This will only execute the effect when values in the first argument change.
       *
       * @see https://reactjs.org/docs/hooks-reference.html#useLayoutEffect
       */
@@ -796,8 +780,7 @@ object Api {
       * Prefer the standard [[useEffect]] when possible to avoid blocking visual updates.
       *
       * If you'd only like to execute the effect when your component is mounted, then use [[useInsertionEffectOnMount]].
-      * If you'd only like to execute the effect when certain values have changed, provide those certain values as
-      * the first argument.
+      * If you'd only like to execute the effect when certain values have changed, then use [[useInsertionEffectWithDeps]].
       *
       * @see https://react.dev/reference/react/useInsertionEffect#useInsertionEffect
       */
@@ -810,9 +793,7 @@ object Api {
       *
       * Prefer the standard [[useEffect]] when possible to avoid blocking visual updates.
       *
-      * If you'd only like to execute the effect when your component is mounted, then use [[useInsertionEffectOnMount]].
-      * If you'd only like to execute the effect when certain values have changed, provide those certain values as
-      * the first argument.
+      * This will only execute the effect when values in the first argument change.
       *
       * @see https://react.dev/reference/react/useInsertionEffect#useInsertionEffect
       */
@@ -825,9 +806,7 @@ object Api {
       *
       * Prefer the standard [[useEffect]] when possible to avoid blocking visual updates.
       *
-      * If you'd only like to execute the effect when your component is mounted, then use [[useInsertionEffectOnMount]].
-      * If you'd only like to execute the effect when certain values have changed, provide those certain values as
-      * the first argument.
+      * This will only execute the effect when your component is mounted.
       *
       * @see https://react.dev/reference/react/useInsertionEffect#useInsertionEffect
       */

--- a/library/coreGeneric/src/main/scala/japgolly/scalajs/react/hooks/Api.scala
+++ b/library/coreGeneric/src/main/scala/japgolly/scalajs/react/hooks/Api.scala
@@ -622,6 +622,27 @@ object Api {
       */
     final def useSyncExternalStoreBy[F[_], A](subscribe: Ctx => F[Unit] => F[F[Unit]], getSnapshot: Ctx => F[A], getServerSnapshot: js.UndefOr[Ctx => F[A]])(implicit F: Sync[F], step: Step): step.Next[A] =
       customBy(ctx => UseSyncExternalStore(subscribe(ctx), getSnapshot(ctx), getServerSnapshot.map(_(ctx))))
+
+    /**
+      * Lets you defer updating a part of the UI.
+      *
+      * @see
+      *   {@link https://react.dev/reference/react/useDeferredValue}
+      */
+    final def useDeferredValue[A](value: Ctx => A)(implicit step: Step): step.Next[A] =
+      // initialValue was added in React 19 - Replace when we upgrade to React 19
+      // customBy(ctx => UseDeferredValue(value(ctx), js.undefined))
+      customBy(ctx => UseDeferredValue(value(ctx)))
+
+    // initialValue was added in React 19 - Uncomment when we upgrade to React 19
+    // /**
+    //   * Lets you defer updating a part of the UI.
+    //   *
+    //   * @see
+    //   *   {@link https://react.dev/reference/react/useDeferredValue}
+    //   */
+    // final def useDeferredValue[A](value: Ctx => A, initialValue: Ctx => A)(implicit step: Step): step.Next[A] =
+    //   customBy(ctx => UseDeferredValue(value(ctx), initialValue(ctx)))
   }
 
   // ===================================================================================================================
@@ -881,6 +902,26 @@ object Api {
       */
     final def useSyncExternalStoreBy[F[_], A](subscribe: CtxFn[F[Unit] => F[F[Unit]]], getSnapshot: CtxFn[F[A]], getServerSnapshot: js.UndefOr[CtxFn[F[A]]])(implicit F: Sync[F], step: Step): step.Next[A] =
       useSyncExternalStoreBy(ctx => step.squash(subscribe)(ctx), ctx => step.squash(getSnapshot)(ctx), getServerSnapshot.map(f => ctx => step.squash(f)(ctx)))
+
+    /**
+      * Lets you defer updating a part of the UI.
+      *
+      * @see
+      *   {@link https://react.dev/reference/react/useDeferredValue}
+      */
+    @inline final def useDeferredValue[A](value: CtxFn[A])(implicit step: Step): step.Next[A] =
+      useDeferredValue(ctx => step.squash(value)(ctx))
+
+    // initialValue was added in React 19 - Uncomment when we upgrade to React 19
+    // /**
+    //   * Lets you defer updating a part of the UI.
+    //   *
+    //   * @see
+    //   *   {@link https://react.dev/reference/react/useDeferredValue}
+    //   */
+    // final def useDeferredValue[A](value: CtxFn[A], initialValue: CtxFn[A])(implicit step: Step): step.Next[A] =
+    //   // useDeferredValue(ctx => step.squash(value)(ctx), initialValue.map(f => ctx => step.squash(f)(ctx)))
+    //   useDeferredValue(ctx => step.squash(value)(ctx), ctx => step.squash(initialValue)(ctx))
   }
 
   // ===================================================================================================================

--- a/library/coreGeneric/src/main/scala/japgolly/scalajs/react/hooks/Api.scala
+++ b/library/coreGeneric/src/main/scala/japgolly/scalajs/react/hooks/Api.scala
@@ -197,7 +197,7 @@ object Api {
       * By default, effects run after every completed render.
       * If you'd only like to execute the effect when your component is mounted, then use [[useEffectOnMount]].
       * If you'd only like to execute the effect when certain values have changed, provide those certain values as
-      * the second argument.
+      * a first argument.
       *
       * @see https://reactjs.org/docs/hooks-reference.html#useeffect
       */
@@ -210,12 +210,12 @@ object Api {
       * By default, effects run after every completed render.
       * If you'd only like to execute the effect when your component is mounted, then use [[useEffectOnMount]].
       * If you'd only like to execute the effect when certain values have changed, provide those certain values as
-      * the second argument.
+      * a first argument.
       *
       * @see https://reactjs.org/docs/hooks-reference.html#useeffect
       */
-    final def useEffectBy[A](init: Ctx => A)(implicit a: UseEffectArg[A], step: Step): step.Self =
-      self(ctx => UseEffect.unsafeCreate(init(ctx)))
+    final def useEffectBy[A](effect: Ctx => A)(implicit a: UseEffectArg[A], step: Step): step.Self =
+      self(ctx => UseEffect.unsafeCreate(effect(ctx)))
 
     /** The callback passed to useEffect will run after the render is committed to the screen. Think of effects as an
       * escape hatch from React’s purely functional world into the imperative world.
@@ -240,7 +240,7 @@ object Api {
     /** The callback passed to useEffect will run after the render is committed to the screen. Think of effects as an
       * escape hatch from React’s purely functional world into the imperative world.
       *
-      * This will only execute the effect when values in the second argument, change.
+      * This will only execute the effect when values in a first argument, change.
       *
       * @see https://reactjs.org/docs/hooks-reference.html#useeffect
       */
@@ -250,7 +250,7 @@ object Api {
     /** The callback passed to useEffect will run after the render is committed to the screen. Think of effects as an
       * escape hatch from React’s purely functional world into the imperative world.
       *
-      * This will only execute the effect when values in the second argument, change.
+      * This will only execute the effect when values in a first argument, change.
       *
       * @see https://reactjs.org/docs/hooks-reference.html#useeffect
       */
@@ -269,7 +269,7 @@ object Api {
       *
       * If you'd only like to execute the effect when your component is mounted, then use [[useLayoutEffectOnMount]].
       * If you'd only like to execute the effect when certain values have changed, provide those certain values as
-      * the second argument.
+      * a first argument.
       *
       * @see https://reactjs.org/docs/hooks-reference.html#useLayoutEffect
       */
@@ -284,12 +284,12 @@ object Api {
       *
       * If you'd only like to execute the effect when your component is mounted, then use [[useLayoutEffectOnMount]].
       * If you'd only like to execute the effect when certain values have changed, provide those certain values as
-      * the second argument.
+      * a first argument.
       *
       * @see https://reactjs.org/docs/hooks-reference.html#useLayoutEffect
       */
-    final def useLayoutEffectBy[A](init: Ctx => A)(implicit a: UseEffectArg[A], step: Step): step.Self =
-      self(ctx => UseEffect.unsafeCreateLayout(init(ctx)))
+    final def useLayoutEffectBy[A](effect: Ctx => A)(implicit a: UseEffectArg[A], step: Step): step.Self =
+      self(ctx => UseEffect.unsafeCreateLayout(effect(ctx)))
 
     /** The signature is identical to [[useEffect]], but it fires synchronously after all DOM mutations. Use this to
       * read layout from the DOM and synchronously re-render. Updates scheduled inside useLayoutEffect will be flushed
@@ -323,7 +323,7 @@ object Api {
       *
       * Prefer the standard [[useEffect]] when possible to avoid blocking visual updates.
       *
-      * This will only execute the effect when values in the second argument, change.
+      * This will only execute the effect when values in a first argument, change.
       *
       * @see https://reactjs.org/docs/hooks-reference.html#useLayoutEffect
       */
@@ -336,99 +336,102 @@ object Api {
       *
       * Prefer the standard [[useEffect]] when possible to avoid blocking visual updates.
       *
-      * This will only execute the effect when values in the second argument, change.
+      * This will only execute the effect when values in a first argument, change.
       *
       * @see https://reactjs.org/docs/hooks-reference.html#useLayoutEffect
       */
     final def useLayoutEffectWithDepsBy[D, A](deps: Ctx => D)(effect: Ctx => D => A)(implicit a: UseEffectArg[A], r: Reusability[D], step: Step): step.Self =
       customBy(ctx => ReusableEffect.useLayoutEffect(deps(ctx))(effect(ctx)))
 
-    //************
-
-    /** The signature is identical to [[useEffect]], but it fires synchronously after all DOM mutations. Use this to
-      * read Insertion from the DOM and synchronously re-render. Updates scheduled inside useInsertionEffect will be flushed
-      * synchronously, before the browser has a chance to paint.
+    /** The signature is identical to [[useEffect]], but it fires synchronously after all DOM mutations, but before any 
+      * layout Effects fire. Use this to insert styles before any Effects fire that may need to read layout. Updates 
+      * scheduled inside useLayoutEffect will be flushed synchronously, before the browser has a chance to paint.
       *
       * Prefer the standard [[useEffect]] when possible to avoid blocking visual updates.
       *
       * If you'd only like to execute the effect when your component is mounted, then use [[useInsertionEffectOnMount]].
       * If you'd only like to execute the effect when certain values have changed, provide those certain values as
-      * the second argument.
+      * the first argument.
       *
-      * @see https://react.dev/reference/react/useInsertionEffect#useinsertioneffect
+      * @see https://react.dev/reference/react/useInsertionEffect#useInsertionEffect
       */
     final def useInsertionEffect[A](effect: A)(implicit a: UseEffectArg[A], step: Step): step.Self =
       useInsertionEffectBy(_ => effect)
 
-    /** The signature is identical to [[useEffect]], but it fires synchronously after all DOM mutations. Use this to
-      * read Insertion from the DOM and synchronously re-render. Updates scheduled inside useInsertionEffect will be flushed
-      * synchronously, before the browser has a chance to paint.
+    /** The signature is identical to [[useEffect]], but it fires synchronously after all DOM mutations, but before any 
+      * layout Effects fire. Use this to insert styles before any Effects fire that may need to read layout. Updates 
+      * scheduled inside useLayoutEffect will be flushed synchronously, before the browser has a chance to paint.
       *
       * Prefer the standard [[useEffect]] when possible to avoid blocking visual updates.
       *
       * If you'd only like to execute the effect when your component is mounted, then use [[useInsertionEffectOnMount]].
       * If you'd only like to execute the effect when certain values have changed, provide those certain values as
-      * the second argument.
+      * the first argument.
       *
-      * @see https://react.dev/reference/react/useInsertionEffect#useinsertioneffect
+      * @see https://react.dev/reference/react/useInsertionEffect#useInsertionEffect
       */
-    final def useInsertionEffectBy[A](init: Ctx => A)(implicit a: UseEffectArg[A], step: Step): step.Self =
-      self(ctx => UseEffect.unsafeCreateInsertion(init(ctx)))
+    final def useInsertionEffectBy[A](effect: Ctx => A)(implicit a: UseEffectArg[A], step: Step): step.Self =
+      self(ctx => UseEffect.unsafeCreateInsertion(effect(ctx)))
 
-    /** The signature is identical to [[useEffect]], but it fires synchronously after all DOM mutations. Use this to
-      * read Insertion from the DOM and synchronously re-render. Updates scheduled inside useInsertionEffect will be flushed
-      * synchronously, before the browser has a chance to paint.
+    /** The signature is identical to [[useEffect]], but it fires synchronously after all DOM mutations, but before any 
+      * layout Effects fire. Use this to insert styles before any Effects fire that may need to read layout. Updates 
+      * scheduled inside useLayoutEffect will be flushed synchronously, before the browser has a chance to paint.
       *
       * Prefer the standard [[useEffect]] when possible to avoid blocking visual updates.
       *
-      * This will only execute the effect when your component is mounted.
+      * If you'd only like to execute the effect when your component is mounted, then use [[useInsertionEffectOnMount]].
+      * If you'd only like to execute the effect when certain values have changed, provide those certain values as
+      * the first argument.
       *
-      * @see https://react.dev/reference/react/useInsertionEffect#useinsertioneffect
+      * @see https://react.dev/reference/react/useInsertionEffect#useInsertionEffect
       */
     final def useInsertionEffectOnMount[A](effect: A)(implicit a: UseEffectArg[A], step: Step): step.Self =
       useInsertionEffectOnMountBy(_ => effect)
 
-    /** The signature is identical to [[useEffect]], but it fires synchronously after all DOM mutations. Use this to
-      * read Insertion from the DOM and synchronously re-render. Updates scheduled inside useInsertionEffect will be flushed
-      * synchronously, before the browser has a chance to paint.
+    /** The signature is identical to [[useEffect]], but it fires synchronously after all DOM mutations, but before any 
+      * layout Effects fire. Use this to insert styles before any Effects fire that may need to read layout. Updates 
+      * scheduled inside useLayoutEffect will be flushed synchronously, before the browser has a chance to paint.
       *
       * Prefer the standard [[useEffect]] when possible to avoid blocking visual updates.
       *
-      * This will only execute the effect when your component is mounted.
+      * If you'd only like to execute the effect when your component is mounted, then use [[useInsertionEffectOnMount]].
+      * If you'd only like to execute the effect when certain values have changed, provide those certain values as
+      * the first argument.
       *
-      * @see https://react.dev/reference/react/useInsertionEffect#useinsertioneffect
+      * @see https://react.dev/reference/react/useInsertionEffect#useInsertionEffect
       */
     final def useInsertionEffectOnMountBy[A](effect: Ctx => A)(implicit a: UseEffectArg[A], step: Step): step.Self =
       self(ctx => UseEffect.unsafeCreateInsertionOnMount(effect(ctx)))
 
-    /** The signature is identical to [[useEffect]], but it fires synchronously after all DOM mutations. Use this to
-      * read Insertion from the DOM and synchronously re-render. Updates scheduled inside useInsertionEffect will be flushed
-      * synchronously, before the browser has a chance to paint.
+    /** The signature is identical to [[useEffect]], but it fires synchronously after all DOM mutations, but before any 
+      * layout Effects fire. Use this to insert styles before any Effects fire that may need to read layout. Updates 
+      * scheduled inside useLayoutEffect will be flushed synchronously, before the browser has a chance to paint.
       *
       * Prefer the standard [[useEffect]] when possible to avoid blocking visual updates.
       *
-      * This will only execute the effect when values in the second argument, change.
+      * If you'd only like to execute the effect when your component is mounted, then use [[useInsertionEffectOnMount]].
+      * If you'd only like to execute the effect when certain values have changed, provide those certain values as
+      * the first argument.
       *
-      * @see https://react.dev/reference/react/useInsertionEffect#useinsertioneffect
+      * @see https://react.dev/reference/react/useInsertionEffect#useInsertionEffect
       */
     final def useInsertionEffectWithDeps[D, A](deps: => D)(effect: D => A)(implicit a: UseEffectArg[A], r: Reusability[D], step: Step): step.Self =
       custom(ReusableEffect.useInsertionEffect(deps)(effect))
 
-    /** The signature is identical to [[useEffect]], but it fires synchronously after all DOM mutations. Use this to
-      * read Insertion from the DOM and synchronously re-render. Updates scheduled inside useInsertionEffect will be flushed
-      * synchronously, before the browser has a chance to paint.
+    /** The signature is identical to [[useEffect]], but it fires synchronously after all DOM mutations, but before any 
+      * layout Effects fire. Use this to insert styles before any Effects fire that may need to read layout. Updates 
+      * scheduled inside useLayoutEffect will be flushed synchronously, before the browser has a chance to paint.
       *
       * Prefer the standard [[useEffect]] when possible to avoid blocking visual updates.
       *
-      * This will only execute the effect when values in the second argument, change.
+      * If you'd only like to execute the effect when your component is mounted, then use [[useInsertionEffectOnMount]].
+      * If you'd only like to execute the effect when certain values have changed, provide those certain values as
+      * the first argument.
       *
-      * @see https://react.dev/reference/react/useInsertionEffect#useinsertioneffect
+      * @see https://react.dev/reference/react/useInsertionEffect#useInsertionEffect
       */
     final def useInsertionEffectWithDepsBy[D, A](deps: Ctx => D)(effect: Ctx => D => A)(implicit a: UseEffectArg[A], r: Reusability[D], step: Step): step.Self =
       customBy(ctx => ReusableEffect.useInsertionEffect(deps(ctx))(effect(ctx)))
-
-
-    //************
 
     /** Returns a memoized value.
       *
@@ -697,17 +700,17 @@ object Api {
       * By default, effects run after every completed render.
       * If you'd only like to execute the effect when your component is mounted, then use [[useEffectOnMount]].
       * If you'd only like to execute the effect when certain values have changed, provide those certain values as
-      * the second argument.
+      * a first argument.
       *
       * @see https://reactjs.org/docs/hooks-reference.html#useeffect
       */
-    final def useEffectBy[A](init: CtxFn[A])(implicit a: UseEffectArg[A], step: Step): step.Self =
-      useEffectBy(step.squash(init)(_))
+    final def useEffectBy[A](effect: CtxFn[A])(implicit a: UseEffectArg[A], step: Step): step.Self =
+      useEffectBy(step.squash(effect)(_))
 
     /** The callback passed to useEffect will run after the render is committed to the screen. Think of effects as an
       * escape hatch from React’s purely functional world into the imperative world.
       *
-      * This will only execute the effect when values in the second argument, change.
+      * This will only execute the effect when values in a first argument, change.
       *
       * @see https://reactjs.org/docs/hooks-reference.html#useeffect
       */
@@ -732,12 +735,12 @@ object Api {
       *
       * If you'd only like to execute the effect when your component is mounted, then use [[useLayoutEffectOnMount]].
       * If you'd only like to execute the effect when certain values have changed, provide those certain values as
-      * the second argument.
+      * a first argument.
       *
       * @see https://reactjs.org/docs/hooks-reference.html#useLayoutEffect
       */
-    final def useLayoutEffectBy[A](init: CtxFn[A])(implicit a: UseEffectArg[A], step: Step): step.Self =
-      useLayoutEffectBy(step.squash(init)(_))
+    final def useLayoutEffectBy[A](effect: CtxFn[A])(implicit a: UseEffectArg[A], step: Step): step.Self =
+      useLayoutEffectBy(step.squash(effect)(_))
 
     /** The signature is identical to [[useEffect]], but it fires synchronously after all DOM mutations. Use this to
       * read layout from the DOM and synchronously re-render. Updates scheduled inside useLayoutEffect will be flushed
@@ -745,7 +748,7 @@ object Api {
       *
       * Prefer the standard [[useEffect]] when possible to avoid blocking visual updates.
       *
-      * This will only execute the effect when values in the second argument, change.
+      * This will only execute the effect when values in a first argument, change.
       *
       * @see https://reactjs.org/docs/hooks-reference.html#useLayoutEffect
       */
@@ -764,6 +767,51 @@ object Api {
       */
     final def useLayoutEffectOnMountBy[A](effect: CtxFn[A])(implicit a: UseEffectArg[A], step: Step): step.Self =
       useLayoutEffectOnMountBy(step.squash(effect)(_))
+
+/** The signature is identical to [[useEffect]], but it fires synchronously after all DOM mutations, but before any 
+      * layout Effects fire. Use this to insert styles before any Effects fire that may need to read layout. Updates 
+      * scheduled inside useLayoutEffect will be flushed synchronously, before the browser has a chance to paint.
+      *
+      * Prefer the standard [[useEffect]] when possible to avoid blocking visual updates.
+      *
+      * If you'd only like to execute the effect when your component is mounted, then use [[useInsertionEffectOnMount]].
+      * If you'd only like to execute the effect when certain values have changed, provide those certain values as
+      * the first argument.
+      *
+      * @see https://react.dev/reference/react/useInsertionEffect#useInsertionEffect
+      */
+    final def useInsertionEffectBy[A](effect: CtxFn[A])(implicit a: UseEffectArg[A], step: Step): step.Self =
+      useInsertionEffectBy(step.squash(effect)(_))
+
+    /** The signature is identical to [[useEffect]], but it fires synchronously after all DOM mutations, but before any 
+      * layout Effects fire. Use this to insert styles before any Effects fire that may need to read layout. Updates 
+      * scheduled inside useLayoutEffect will be flushed synchronously, before the browser has a chance to paint.
+      *
+      * Prefer the standard [[useEffect]] when possible to avoid blocking visual updates.
+      *
+      * If you'd only like to execute the effect when your component is mounted, then use [[useInsertionEffectOnMount]].
+      * If you'd only like to execute the effect when certain values have changed, provide those certain values as
+      * the first argument.
+      *
+      * @see https://react.dev/reference/react/useInsertionEffect#useInsertionEffect
+      */
+    final def useInsertionEffectWithDepsBy[D, A](deps: CtxFn[D])(effect: CtxFn[D => A])(implicit a: UseEffectArg[A], r: Reusability[D], step: Step): step.Self =
+      useInsertionEffectWithDepsBy(step.squash(deps)(_))(step.squash(effect)(_))
+
+    /** The signature is identical to [[useEffect]], but it fires synchronously after all DOM mutations, but before any 
+      * layout Effects fire. Use this to insert styles before any Effects fire that may need to read layout. Updates 
+      * scheduled inside useLayoutEffect will be flushed synchronously, before the browser has a chance to paint.
+      *
+      * Prefer the standard [[useEffect]] when possible to avoid blocking visual updates.
+      *
+      * If you'd only like to execute the effect when your component is mounted, then use [[useInsertionEffectOnMount]].
+      * If you'd only like to execute the effect when certain values have changed, provide those certain values as
+      * the first argument.
+      *
+      * @see https://react.dev/reference/react/useInsertionEffect#useInsertionEffect
+      */
+    final def useInsertionEffectOnMountBy[A](effect: CtxFn[A])(implicit a: UseEffectArg[A], step: Step): step.Self =
+      useInsertionEffectOnMountBy(step.squash(effect)(_))
 
     /** Returns a memoized value.
       *

--- a/library/coreGeneric/src/main/scala/japgolly/scalajs/react/hooks/Api.scala
+++ b/library/coreGeneric/src/main/scala/japgolly/scalajs/react/hooks/Api.scala
@@ -768,7 +768,7 @@ object Api {
     final def useLayoutEffectOnMountBy[A](effect: CtxFn[A])(implicit a: UseEffectArg[A], step: Step): step.Self =
       useLayoutEffectOnMountBy(step.squash(effect)(_))
 
-/** The signature is identical to [[useEffect]], but it fires synchronously after all DOM mutations, but before any 
+    /** The signature is identical to [[useEffect]], but it fires synchronously after all DOM mutations, but before any 
       * layout Effects fire. Use this to insert styles before any Effects fire that may need to read layout. Updates 
       * scheduled inside useLayoutEffect will be flushed synchronously, before the browser has a chance to paint.
       *

--- a/library/coreGeneric/src/main/scala/japgolly/scalajs/react/hooks/Hooks.scala
+++ b/library/coreGeneric/src/main/scala/japgolly/scalajs/react/hooks/Hooks.scala
@@ -503,4 +503,13 @@ object Hooks {
       CustomHook.delay(facade.React.useSyncExternalStore(subscribeJs, getSnapshotJs, getServerSnapshotJs))
     }
   }
+
+  object UseDeferredValue {
+  // initialValue was added in React 19 - Replace when we upgrade to React 19
+    // def apply[A](value: A, initialValue: js.UndefOr[A] = js.undefined): CustomHook[Unit, A] =
+    //   CustomHook.delay(facade.React.useDeferredValue(value, initialValue))
+
+    def apply[A](value: A): CustomHook[Unit, A] =
+      CustomHook.delay(facade.React.useDeferredValue(value))
+  }
 }

--- a/library/coreGeneric/src/main/scala/japgolly/scalajs/react/hooks/UseCallbackBoilerplate.scala
+++ b/library/coreGeneric/src/main/scala/japgolly/scalajs/react/hooks/UseCallbackBoilerplate.scala
@@ -20,9 +20,19 @@ trait UseCallbackArgInstances {
       z => (a) => Z.dispatch(z(a)))(
       z => Reusable.byRef(z).withValue((a) => Z.delay(z(a))))
 
+  implicit def ci1[A, Y, Z[_]](implicit Z: UnsafeSync[Z]): UseCallbackArg[(A) => Z[Y]] =
+    UseCallbackArg[(A) => Z[Y], js.Function1[A, Y]](
+      z => (a) => Z.runSync(z(a)))(
+      z => Reusable.byRef(z).withValue((a) => Z.delay(z(a))))
+
   implicit def c2[A, B, Z[_]](implicit Z: Dispatch[Z]): UseCallbackArg[(A, B) => Z[Unit]] =
     UseCallbackArg[(A, B) => Z[Unit], js.Function2[A, B, Unit]](
       z => (a, b) => Z.dispatch(z(a, b)))(
+      z => Reusable.byRef(z).withValue((a, b) => Z.delay(z(a, b))))
+
+  implicit def ci2[A, B, Y, Z[_]](implicit Z: UnsafeSync[Z]): UseCallbackArg[(A, B) => Z[Y]] =
+    UseCallbackArg[(A, B) => Z[Y], js.Function2[A, B, Y]](
+      z => (a, b) => Z.runSync(z(a, b)))(
       z => Reusable.byRef(z).withValue((a, b) => Z.delay(z(a, b))))
 
   implicit def c3[A, B, C, Z[_]](implicit Z: Dispatch[Z]): UseCallbackArg[(A, B, C) => Z[Unit]] =
@@ -30,9 +40,19 @@ trait UseCallbackArgInstances {
       z => (a, b, c) => Z.dispatch(z(a, b, c)))(
       z => Reusable.byRef(z).withValue((a, b, c) => Z.delay(z(a, b, c))))
 
+  implicit def ci3[A, B, C, Y, Z[_]](implicit Z: UnsafeSync[Z]): UseCallbackArg[(A, B, C) => Z[Y]] =
+    UseCallbackArg[(A, B, C) => Z[Y], js.Function3[A, B, C, Y]](
+      z => (a, b, c) => Z.runSync(z(a, b, c)))(
+      z => Reusable.byRef(z).withValue((a, b, c) => Z.delay(z(a, b, c))))
+
   implicit def c4[A, B, C, D, Z[_]](implicit Z: Dispatch[Z]): UseCallbackArg[(A, B, C, D) => Z[Unit]] =
     UseCallbackArg[(A, B, C, D) => Z[Unit], js.Function4[A, B, C, D, Unit]](
       z => (a, b, c, d) => Z.dispatch(z(a, b, c, d)))(
+      z => Reusable.byRef(z).withValue((a, b, c, d) => Z.delay(z(a, b, c, d))))
+
+  implicit def ci4[A, B, C, D, Y, Z[_]](implicit Z: UnsafeSync[Z]): UseCallbackArg[(A, B, C, D) => Z[Y]] =
+    UseCallbackArg[(A, B, C, D) => Z[Y], js.Function4[A, B, C, D, Y]](
+      z => (a, b, c, d) => Z.runSync(z(a, b, c, d)))(
       z => Reusable.byRef(z).withValue((a, b, c, d) => Z.delay(z(a, b, c, d))))
 
   implicit def c5[A, B, C, D, E, Z[_]](implicit Z: Dispatch[Z]): UseCallbackArg[(A, B, C, D, E) => Z[Unit]] =
@@ -40,9 +60,19 @@ trait UseCallbackArgInstances {
       z => (a, b, c, d, e) => Z.dispatch(z(a, b, c, d, e)))(
       z => Reusable.byRef(z).withValue((a, b, c, d, e) => Z.delay(z(a, b, c, d, e))))
 
+  implicit def ci5[A, B, C, D, E, Y, Z[_]](implicit Z: UnsafeSync[Z]): UseCallbackArg[(A, B, C, D, E) => Z[Y]] =
+    UseCallbackArg[(A, B, C, D, E) => Z[Y], js.Function5[A, B, C, D, E, Y]](
+      z => (a, b, c, d, e) => Z.runSync(z(a, b, c, d, e)))(
+      z => Reusable.byRef(z).withValue((a, b, c, d, e) => Z.delay(z(a, b, c, d, e))))
+
   implicit def c6[A, B, C, D, E, F, Z[_]](implicit Z: Dispatch[Z]): UseCallbackArg[(A, B, C, D, E, F) => Z[Unit]] =
     UseCallbackArg[(A, B, C, D, E, F) => Z[Unit], js.Function6[A, B, C, D, E, F, Unit]](
       z => (a, b, c, d, e, f) => Z.dispatch(z(a, b, c, d, e, f)))(
+      z => Reusable.byRef(z).withValue((a, b, c, d, e, f) => Z.delay(z(a, b, c, d, e, f))))
+
+  implicit def ci6[A, B, C, D, E, F, Y, Z[_]](implicit Z: UnsafeSync[Z]): UseCallbackArg[(A, B, C, D, E, F) => Z[Y]] =
+    UseCallbackArg[(A, B, C, D, E, F) => Z[Y], js.Function6[A, B, C, D, E, F, Y]](
+      z => (a, b, c, d, e, f) => Z.runSync(z(a, b, c, d, e, f)))(
       z => Reusable.byRef(z).withValue((a, b, c, d, e, f) => Z.delay(z(a, b, c, d, e, f))))
 
   implicit def c7[A, B, C, D, E, F, G, Z[_]](implicit Z: Dispatch[Z]): UseCallbackArg[(A, B, C, D, E, F, G) => Z[Unit]] =
@@ -50,9 +80,19 @@ trait UseCallbackArgInstances {
       z => (a, b, c, d, e, f, g) => Z.dispatch(z(a, b, c, d, e, f, g)))(
       z => Reusable.byRef(z).withValue((a, b, c, d, e, f, g) => Z.delay(z(a, b, c, d, e, f, g))))
 
+  implicit def ci7[A, B, C, D, E, F, G, Y, Z[_]](implicit Z: UnsafeSync[Z]): UseCallbackArg[(A, B, C, D, E, F, G) => Z[Y]] =
+    UseCallbackArg[(A, B, C, D, E, F, G) => Z[Y], js.Function7[A, B, C, D, E, F, G, Y]](
+      z => (a, b, c, d, e, f, g) => Z.runSync(z(a, b, c, d, e, f, g)))(
+      z => Reusable.byRef(z).withValue((a, b, c, d, e, f, g) => Z.delay(z(a, b, c, d, e, f, g))))
+
   implicit def c8[A, B, C, D, E, F, G, H, Z[_]](implicit Z: Dispatch[Z]): UseCallbackArg[(A, B, C, D, E, F, G, H) => Z[Unit]] =
     UseCallbackArg[(A, B, C, D, E, F, G, H) => Z[Unit], js.Function8[A, B, C, D, E, F, G, H, Unit]](
       z => (a, b, c, d, e, f, g, h) => Z.dispatch(z(a, b, c, d, e, f, g, h)))(
+      z => Reusable.byRef(z).withValue((a, b, c, d, e, f, g, h) => Z.delay(z(a, b, c, d, e, f, g, h))))
+
+  implicit def ci8[A, B, C, D, E, F, G, H, Y, Z[_]](implicit Z: UnsafeSync[Z]): UseCallbackArg[(A, B, C, D, E, F, G, H) => Z[Y]] =
+    UseCallbackArg[(A, B, C, D, E, F, G, H) => Z[Y], js.Function8[A, B, C, D, E, F, G, H, Y]](
+      z => (a, b, c, d, e, f, g, h) => Z.runSync(z(a, b, c, d, e, f, g, h)))(
       z => Reusable.byRef(z).withValue((a, b, c, d, e, f, g, h) => Z.delay(z(a, b, c, d, e, f, g, h))))
 
   implicit def c9[A, B, C, D, E, F, G, H, I, Z[_]](implicit Z: Dispatch[Z]): UseCallbackArg[(A, B, C, D, E, F, G, H, I) => Z[Unit]] =
@@ -60,9 +100,19 @@ trait UseCallbackArgInstances {
       z => (a, b, c, d, e, f, g, h, i) => Z.dispatch(z(a, b, c, d, e, f, g, h, i)))(
       z => Reusable.byRef(z).withValue((a, b, c, d, e, f, g, h, i) => Z.delay(z(a, b, c, d, e, f, g, h, i))))
 
+  implicit def ci9[A, B, C, D, E, F, G, H, I, Y, Z[_]](implicit Z: UnsafeSync[Z]): UseCallbackArg[(A, B, C, D, E, F, G, H, I) => Z[Y]] =
+    UseCallbackArg[(A, B, C, D, E, F, G, H, I) => Z[Y], js.Function9[A, B, C, D, E, F, G, H, I, Y]](
+      z => (a, b, c, d, e, f, g, h, i) => Z.runSync(z(a, b, c, d, e, f, g, h, i)))(
+      z => Reusable.byRef(z).withValue((a, b, c, d, e, f, g, h, i) => Z.delay(z(a, b, c, d, e, f, g, h, i))))
+
   implicit def c10[A, B, C, D, E, F, G, H, I, J, Z[_]](implicit Z: Dispatch[Z]): UseCallbackArg[(A, B, C, D, E, F, G, H, I, J) => Z[Unit]] =
     UseCallbackArg[(A, B, C, D, E, F, G, H, I, J) => Z[Unit], js.Function10[A, B, C, D, E, F, G, H, I, J, Unit]](
       z => (a, b, c, d, e, f, g, h, i, j) => Z.dispatch(z(a, b, c, d, e, f, g, h, i, j)))(
+      z => Reusable.byRef(z).withValue((a, b, c, d, e, f, g, h, i, j) => Z.delay(z(a, b, c, d, e, f, g, h, i, j))))
+
+  implicit def ci10[A, B, C, D, E, F, G, H, I, J, Y, Z[_]](implicit Z: UnsafeSync[Z]): UseCallbackArg[(A, B, C, D, E, F, G, H, I, J) => Z[Y]] =
+    UseCallbackArg[(A, B, C, D, E, F, G, H, I, J) => Z[Y], js.Function10[A, B, C, D, E, F, G, H, I, J, Y]](
+      z => (a, b, c, d, e, f, g, h, i, j) => Z.runSync(z(a, b, c, d, e, f, g, h, i, j)))(
       z => Reusable.byRef(z).withValue((a, b, c, d, e, f, g, h, i, j) => Z.delay(z(a, b, c, d, e, f, g, h, i, j))))
 
   implicit def c11[A, B, C, D, E, F, G, H, I, J, K, Z[_]](implicit Z: Dispatch[Z]): UseCallbackArg[(A, B, C, D, E, F, G, H, I, J, K) => Z[Unit]] =
@@ -70,9 +120,19 @@ trait UseCallbackArgInstances {
       z => (a, b, c, d, e, f, g, h, i, j, k) => Z.dispatch(z(a, b, c, d, e, f, g, h, i, j, k)))(
       z => Reusable.byRef(z).withValue((a, b, c, d, e, f, g, h, i, j, k) => Z.delay(z(a, b, c, d, e, f, g, h, i, j, k))))
 
+  implicit def ci11[A, B, C, D, E, F, G, H, I, J, K, Y, Z[_]](implicit Z: UnsafeSync[Z]): UseCallbackArg[(A, B, C, D, E, F, G, H, I, J, K) => Z[Y]] =
+    UseCallbackArg[(A, B, C, D, E, F, G, H, I, J, K) => Z[Y], js.Function11[A, B, C, D, E, F, G, H, I, J, K, Y]](
+      z => (a, b, c, d, e, f, g, h, i, j, k) => Z.runSync(z(a, b, c, d, e, f, g, h, i, j, k)))(
+      z => Reusable.byRef(z).withValue((a, b, c, d, e, f, g, h, i, j, k) => Z.delay(z(a, b, c, d, e, f, g, h, i, j, k))))
+
   implicit def c12[A, B, C, D, E, F, G, H, I, J, K, L, Z[_]](implicit Z: Dispatch[Z]): UseCallbackArg[(A, B, C, D, E, F, G, H, I, J, K, L) => Z[Unit]] =
     UseCallbackArg[(A, B, C, D, E, F, G, H, I, J, K, L) => Z[Unit], js.Function12[A, B, C, D, E, F, G, H, I, J, K, L, Unit]](
       z => (a, b, c, d, e, f, g, h, i, j, k, l) => Z.dispatch(z(a, b, c, d, e, f, g, h, i, j, k, l)))(
+      z => Reusable.byRef(z).withValue((a, b, c, d, e, f, g, h, i, j, k, l) => Z.delay(z(a, b, c, d, e, f, g, h, i, j, k, l))))
+
+  implicit def ci12[A, B, C, D, E, F, G, H, I, J, K, L, Y, Z[_]](implicit Z: UnsafeSync[Z]): UseCallbackArg[(A, B, C, D, E, F, G, H, I, J, K, L) => Z[Y]] =
+    UseCallbackArg[(A, B, C, D, E, F, G, H, I, J, K, L) => Z[Y], js.Function12[A, B, C, D, E, F, G, H, I, J, K, L, Y]](
+      z => (a, b, c, d, e, f, g, h, i, j, k, l) => Z.runSync(z(a, b, c, d, e, f, g, h, i, j, k, l)))(
       z => Reusable.byRef(z).withValue((a, b, c, d, e, f, g, h, i, j, k, l) => Z.delay(z(a, b, c, d, e, f, g, h, i, j, k, l))))
 
   implicit def c13[A, B, C, D, E, F, G, H, I, J, K, L, M, Z[_]](implicit Z: Dispatch[Z]): UseCallbackArg[(A, B, C, D, E, F, G, H, I, J, K, L, M) => Z[Unit]] =
@@ -80,9 +140,19 @@ trait UseCallbackArgInstances {
       z => (a, b, c, d, e, f, g, h, i, j, k, l, m) => Z.dispatch(z(a, b, c, d, e, f, g, h, i, j, k, l, m)))(
       z => Reusable.byRef(z).withValue((a, b, c, d, e, f, g, h, i, j, k, l, m) => Z.delay(z(a, b, c, d, e, f, g, h, i, j, k, l, m))))
 
+  implicit def ci13[A, B, C, D, E, F, G, H, I, J, K, L, M, Y, Z[_]](implicit Z: UnsafeSync[Z]): UseCallbackArg[(A, B, C, D, E, F, G, H, I, J, K, L, M) => Z[Y]] =
+    UseCallbackArg[(A, B, C, D, E, F, G, H, I, J, K, L, M) => Z[Y], js.Function13[A, B, C, D, E, F, G, H, I, J, K, L, M, Y]](
+      z => (a, b, c, d, e, f, g, h, i, j, k, l, m) => Z.runSync(z(a, b, c, d, e, f, g, h, i, j, k, l, m)))(
+      z => Reusable.byRef(z).withValue((a, b, c, d, e, f, g, h, i, j, k, l, m) => Z.delay(z(a, b, c, d, e, f, g, h, i, j, k, l, m))))
+
   implicit def c14[A, B, C, D, E, F, G, H, I, J, K, L, M, N, Z[_]](implicit Z: Dispatch[Z]): UseCallbackArg[(A, B, C, D, E, F, G, H, I, J, K, L, M, N) => Z[Unit]] =
     UseCallbackArg[(A, B, C, D, E, F, G, H, I, J, K, L, M, N) => Z[Unit], js.Function14[A, B, C, D, E, F, G, H, I, J, K, L, M, N, Unit]](
       z => (a, b, c, d, e, f, g, h, i, j, k, l, m, n) => Z.dispatch(z(a, b, c, d, e, f, g, h, i, j, k, l, m, n)))(
+      z => Reusable.byRef(z).withValue((a, b, c, d, e, f, g, h, i, j, k, l, m, n) => Z.delay(z(a, b, c, d, e, f, g, h, i, j, k, l, m, n))))
+
+  implicit def ci14[A, B, C, D, E, F, G, H, I, J, K, L, M, N, Y, Z[_]](implicit Z: UnsafeSync[Z]): UseCallbackArg[(A, B, C, D, E, F, G, H, I, J, K, L, M, N) => Z[Y]] =
+    UseCallbackArg[(A, B, C, D, E, F, G, H, I, J, K, L, M, N) => Z[Y], js.Function14[A, B, C, D, E, F, G, H, I, J, K, L, M, N, Y]](
+      z => (a, b, c, d, e, f, g, h, i, j, k, l, m, n) => Z.runSync(z(a, b, c, d, e, f, g, h, i, j, k, l, m, n)))(
       z => Reusable.byRef(z).withValue((a, b, c, d, e, f, g, h, i, j, k, l, m, n) => Z.delay(z(a, b, c, d, e, f, g, h, i, j, k, l, m, n))))
 
   implicit def c15[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, Z[_]](implicit Z: Dispatch[Z]): UseCallbackArg[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) => Z[Unit]] =
@@ -90,9 +160,19 @@ trait UseCallbackArgInstances {
       z => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) => Z.dispatch(z(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o)))(
       z => Reusable.byRef(z).withValue((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) => Z.delay(z(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o))))
 
+  implicit def ci15[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, Y, Z[_]](implicit Z: UnsafeSync[Z]): UseCallbackArg[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) => Z[Y]] =
+    UseCallbackArg[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) => Z[Y], js.Function15[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, Y]](
+      z => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) => Z.runSync(z(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o)))(
+      z => Reusable.byRef(z).withValue((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) => Z.delay(z(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o))))
+
   implicit def c16[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Z[_]](implicit Z: Dispatch[Z]): UseCallbackArg[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) => Z[Unit]] =
     UseCallbackArg[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) => Z[Unit], js.Function16[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Unit]](
       z => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) => Z.dispatch(z(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p)))(
+      z => Reusable.byRef(z).withValue((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) => Z.delay(z(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p))))
+
+  implicit def ci16[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Y, Z[_]](implicit Z: UnsafeSync[Z]): UseCallbackArg[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) => Z[Y]] =
+    UseCallbackArg[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) => Z[Y], js.Function16[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Y]](
+      z => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) => Z.runSync(z(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p)))(
       z => Reusable.byRef(z).withValue((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) => Z.delay(z(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p))))
 
   implicit def c17[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, Z[_]](implicit Z: Dispatch[Z]): UseCallbackArg[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) => Z[Unit]] =
@@ -100,9 +180,19 @@ trait UseCallbackArgInstances {
       z => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q) => Z.dispatch(z(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q)))(
       z => Reusable.byRef(z).withValue((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q) => Z.delay(z(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q))))
 
+  implicit def ci17[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, Y, Z[_]](implicit Z: UnsafeSync[Z]): UseCallbackArg[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) => Z[Y]] =
+    UseCallbackArg[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) => Z[Y], js.Function17[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, Y]](
+      z => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q) => Z.runSync(z(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q)))(
+      z => Reusable.byRef(z).withValue((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q) => Z.delay(z(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q))))
+
   implicit def c18[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, Z[_]](implicit Z: Dispatch[Z]): UseCallbackArg[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) => Z[Unit]] =
     UseCallbackArg[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) => Z[Unit], js.Function18[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, Unit]](
       z => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r) => Z.dispatch(z(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r)))(
+      z => Reusable.byRef(z).withValue((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r) => Z.delay(z(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r))))
+
+  implicit def ci18[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, Y, Z[_]](implicit Z: UnsafeSync[Z]): UseCallbackArg[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) => Z[Y]] =
+    UseCallbackArg[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) => Z[Y], js.Function18[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, Y]](
+      z => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r) => Z.runSync(z(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r)))(
       z => Reusable.byRef(z).withValue((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r) => Z.delay(z(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r))))
 
   implicit def c19[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, Z[_]](implicit Z: Dispatch[Z]): UseCallbackArg[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) => Z[Unit]] =
@@ -110,9 +200,19 @@ trait UseCallbackArgInstances {
       z => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s) => Z.dispatch(z(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s)))(
       z => Reusable.byRef(z).withValue((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s) => Z.delay(z(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s))))
 
+  implicit def ci19[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, Y, Z[_]](implicit Z: UnsafeSync[Z]): UseCallbackArg[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) => Z[Y]] =
+    UseCallbackArg[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) => Z[Y], js.Function19[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, Y]](
+      z => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s) => Z.runSync(z(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s)))(
+      z => Reusable.byRef(z).withValue((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s) => Z.delay(z(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s))))
+
   implicit def c20[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, Z[_]](implicit Z: Dispatch[Z]): UseCallbackArg[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) => Z[Unit]] =
     UseCallbackArg[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) => Z[Unit], js.Function20[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, Unit]](
       z => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t) => Z.dispatch(z(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t)))(
+      z => Reusable.byRef(z).withValue((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t) => Z.delay(z(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t))))
+
+  implicit def ci20[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, Y, Z[_]](implicit Z: UnsafeSync[Z]): UseCallbackArg[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) => Z[Y]] =
+    UseCallbackArg[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) => Z[Y], js.Function20[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, Y]](
+      z => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t) => Z.runSync(z(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t)))(
       z => Reusable.byRef(z).withValue((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t) => Z.delay(z(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t))))
 
   implicit def c21[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, Z[_]](implicit Z: Dispatch[Z]): UseCallbackArg[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) => Z[Unit]] =
@@ -120,9 +220,19 @@ trait UseCallbackArgInstances {
       z => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u) => Z.dispatch(z(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u)))(
       z => Reusable.byRef(z).withValue((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u) => Z.delay(z(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u))))
 
+  implicit def ci21[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, Y, Z[_]](implicit Z: UnsafeSync[Z]): UseCallbackArg[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) => Z[Y]] =
+    UseCallbackArg[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) => Z[Y], js.Function21[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, Y]](
+      z => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u) => Z.runSync(z(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u)))(
+      z => Reusable.byRef(z).withValue((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u) => Z.delay(z(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u))))
+
   implicit def c22[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, Z[_]](implicit Z: Dispatch[Z]): UseCallbackArg[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) => Z[Unit]] =
     UseCallbackArg[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) => Z[Unit], js.Function22[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, Unit]](
       z => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v) => Z.dispatch(z(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v)))(
+      z => Reusable.byRef(z).withValue((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v) => Z.delay(z(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v))))
+
+  implicit def ci22[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, Y, Z[_]](implicit Z: UnsafeSync[Z]): UseCallbackArg[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) => Z[Y]] =
+    UseCallbackArg[(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) => Z[Y], js.Function22[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, Y]](
+      z => (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v) => Z.runSync(z(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v)))(
       z => Reusable.byRef(z).withValue((a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v) => Z.delay(z(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v))))
 
 }

--- a/library/coreGeneric/src/main/scala/japgolly/scalajs/react/hooks/react17.scala
+++ b/library/coreGeneric/src/main/scala/japgolly/scalajs/react/hooks/react17.scala
@@ -72,7 +72,7 @@ trait react17 {
     *
     * By default, effects run after every completed render. If you'd only like to execute the effect
     * when your component is mounted, then use [[useEffectOnMount]]. If you'd only like to execute the
-    * effect when certain values have changed, provide those certain values as the second argument.
+    * effect when certain values have changed, then use [[useEffectWithDeps]].
     *
     * @see
     *   https://reactjs.org/docs/hooks-reference.html#useeffect
@@ -96,7 +96,7 @@ trait react17 {
     * The callback passed to useEffect will run after the render is committed to the screen. Think of
     * effects as an escape hatch from React’s purely functional world into the imperative world.
     *
-    * This will only execute the effect when values in the second argument, change.
+    * This will only execute the effect when values in the first argument change.
     *
     * @see
     *   https://reactjs.org/docs/hooks-reference.html#useeffect
@@ -115,7 +115,7 @@ trait react17 {
     *
     * If you'd only like to execute the effect when your component is mounted, then use
     * [[useLayoutEffectOnMount]]. If you'd only like to execute the effect when certain values have
-    * changed, provide those certain values as the second argument.
+    * changed, then use [[useLayoutEffectWithDeps]].
     *
     * @see
     *   https://reactjs.org/docs/hooks-reference.html#useLayoutEffect
@@ -145,7 +145,7 @@ trait react17 {
     *
     * Prefer the standard [[useEffect]] when possible to avoid blocking visual updates.
     *
-    * This will only execute the effect when values in the second argument, change.
+    * This will only execute the effect when values in the first argument change.
     *
     * @see
     *   https://reactjs.org/docs/hooks-reference.html#useLayoutEffect

--- a/library/coreGeneric/src/main/scala/japgolly/scalajs/react/hooks/react17.scala
+++ b/library/coreGeneric/src/main/scala/japgolly/scalajs/react/hooks/react17.scala
@@ -6,185 +6,185 @@ import japgolly.scalajs.react.{Reusability, _}
 
 trait react17 {
   /**
-  * Returns a memoized callback.
-  *
-  * Pass an inline callback and dependencies. useCallback will return a memoized version of the
-  * callback that only changes if one of the dependencies has changed. This is useful when passing
-  * callbacks to optimized child components that rely on reference equality to prevent unnecessary
-  * renders.
-  *
-  * @see
-  *   https://reactjs.org/docs/hooks-reference.html#usecallback
-  */
+    * Returns a memoized callback.
+    *
+    * Pass an inline callback and dependencies. useCallback will return a memoized version of the
+    * callback that only changes if one of the dependencies has changed. This is useful when passing
+    * callbacks to optimized child components that rely on reference equality to prevent unnecessary
+    * renders.
+    *
+    * @see
+    *   https://reactjs.org/docs/hooks-reference.html#usecallback
+    */
   @inline final def useCallback[A](callback: A)(implicit isCallbackArg: UseCallbackArg[A]): HookResult[Reusable[A]] =
     UseCallback(callback).toHookResult
 
   /**
-  * Returns a memoized callback.
-  *
-  * Pass an inline callback and dependencies. useCallback will return a memoized version of the
-  * callback that only changes if one of the dependencies has changed. This is useful when passing
-  * callbacks to optimized child components that rely on reference equality to prevent unnecessary
-  * renders.
-  *
-  * @see
-  *   https://reactjs.org/docs/hooks-reference.html#usecallback
-  */
+    * Returns a memoized callback.
+    *
+    * Pass an inline callback and dependencies. useCallback will return a memoized version of the
+    * callback that only changes if one of the dependencies has changed. This is useful when passing
+    * callbacks to optimized child components that rely on reference equality to prevent unnecessary
+    * renders.
+    *
+    * @see
+    *   https://reactjs.org/docs/hooks-reference.html#usecallback
+    */
   @inline final def useCallbackWithDeps[D: Reusability, A](deps: => D)(callback: D => A)(
     implicit isCallbackArg: UseCallbackArg[A]
   ): HookResult[Reusable[A]] =
     UseCallback.withDeps(deps)(callback).toHookResult
 
   /**
-  * Accepts a context object and returns the current context value for that context. The current
-  * context value is determined by the value prop of the nearest `<MyContext.Provider>` above the
-  * calling component in the tree.
-  *
-  * When the nearest `<MyContext.Provider>` above the component updates, this Hook will trigger a
-  * rerender with the latest context value passed to that `MyContext` provider. Even if an ancestor
-  * uses `React.memo` or `shouldComponentUpdate`, a rerender will still happen starting at the
-  * component itself using `useContext`.
-  *
-  * A component calling `useContext` will always re-render when the context value changes. If
-  * re-rendering the component is expensive, you can optimize it by using memoization.
-  *
-  * `useContext(MyContext)` only lets you read the context and subscribe to its changes. You still
-  * need a `<MyContext.Provider>` above in the tree to provide the value for this context.
-  *
-  * @see
-  *   https://reactjs.org/docs/hooks-reference.html#usecontext
-  */
+    * Accepts a context object and returns the current context value for that context. The current
+    * context value is determined by the value prop of the nearest `<MyContext.Provider>` above the
+    * calling component in the tree.
+    *
+    * When the nearest `<MyContext.Provider>` above the component updates, this Hook will trigger a
+    * rerender with the latest context value passed to that `MyContext` provider. Even if an ancestor
+    * uses `React.memo` or `shouldComponentUpdate`, a rerender will still happen starting at the
+    * component itself using `useContext`.
+    *
+    * A component calling `useContext` will always re-render when the context value changes. If
+    * re-rendering the component is expensive, you can optimize it by using memoization.
+    *
+    * `useContext(MyContext)` only lets you read the context and subscribe to its changes. You still
+    * need a `<MyContext.Provider>` above in the tree to provide the value for this context.
+    *
+    * @see
+    *   https://reactjs.org/docs/hooks-reference.html#usecontext
+    */
   @inline final def useContext[A](ctx: Context[A]): HookResult[A] =
     HookResult(UseContext.unsafeCreate(ctx))
 
   /**
-  * Used to display a label for custom hooks in React DevTools.
-  *
-  * @see
-  *   https://reactjs.org/docs/hooks-reference.html#usedebugvalue
-  */
+    * Used to display a label for custom hooks in React DevTools.
+    *
+    * @see
+    *   https://reactjs.org/docs/hooks-reference.html#usedebugvalue
+    */
   @inline final def useDebugValue(desc: => Any): HookResult[Unit] =
     HookResult(UseDebugValue.unsafeCreate(desc))
 
   /**
-  * The callback passed to useEffect will run after the render is committed to the screen. Think of
-  * effects as an escape hatch from React’s purely functional world into the imperative world.
-  *
-  * By default, effects run after every completed render. If you'd only like to execute the effect
-  * when your component is mounted, then use [[useEffectOnMount]]. If you'd only like to execute the
-  * effect when certain values have changed, provide those certain values as the second argument.
-  *
-  * @see
-  *   https://reactjs.org/docs/hooks-reference.html#useeffect
-  */
+    * The callback passed to useEffect will run after the render is committed to the screen. Think of
+    * effects as an escape hatch from React’s purely functional world into the imperative world.
+    *
+    * By default, effects run after every completed render. If you'd only like to execute the effect
+    * when your component is mounted, then use [[useEffectOnMount]]. If you'd only like to execute the
+    * effect when certain values have changed, provide those certain values as the second argument.
+    *
+    * @see
+    *   https://reactjs.org/docs/hooks-reference.html#useeffect
+    */
   @inline final def useEffect[A](effect: A)(implicit isEffectArg: UseEffectArg[A]): HookResult[Unit] =
     HookResult(UseEffect.unsafeCreate(effect))
 
   /**
-  * The callback passed to useEffect will run after the render is committed to the screen. Think of
-  * effects as an escape hatch from React’s purely functional world into the imperative world.
-  *
-  * This will only execute the effect when your component is mounted.
-  *
-  * @see
-  *   https://reactjs.org/docs/hooks-reference.html#useeffect
-  */
+    * The callback passed to useEffect will run after the render is committed to the screen. Think of
+    * effects as an escape hatch from React’s purely functional world into the imperative world.
+    *
+    * This will only execute the effect when your component is mounted.
+    *
+    * @see
+    *   https://reactjs.org/docs/hooks-reference.html#useeffect
+    */
   @inline final def useEffectOnMount[A](effect: A)(implicit isEffectArg: UseEffectArg[A]): HookResult[Unit] =
     HookResult(UseEffect.unsafeCreateOnMount(effect))
 
   /**
-  * The callback passed to useEffect will run after the render is committed to the screen. Think of
-  * effects as an escape hatch from React’s purely functional world into the imperative world.
-  *
-  * This will only execute the effect when values in the second argument, change.
-  *
-  * @see
-  *   https://reactjs.org/docs/hooks-reference.html#useeffect
-  */
+    * The callback passed to useEffect will run after the render is committed to the screen. Think of
+    * effects as an escape hatch from React’s purely functional world into the imperative world.
+    *
+    * This will only execute the effect when values in the second argument, change.
+    *
+    * @see
+    *   https://reactjs.org/docs/hooks-reference.html#useeffect
+    */
   @inline final def useEffectWithDeps[D: Reusability, A](deps: => D)(effect: D => A)(
     implicit isEffectArg: UseEffectArg[A]
   ): HookResult[Unit] =
     ReusableEffect.useEffect(deps)(effect).toHookResult
 
   /**
-  * The signature is identical to [[useEffect]], but it fires synchronously after all DOM mutations.
-  * Use this to read layout from the DOM and synchronously re-render. Updates scheduled inside
-  * useLayoutEffect will be flushed synchronously, before the browser has a chance to paint.
-  *
-  * Prefer the standard [[useEffect]] when possible to avoid blocking visual updates.
-  *
-  * If you'd only like to execute the effect when your component is mounted, then use
-  * [[useLayoutEffectOnMount]]. If you'd only like to execute the effect when certain values have
-  * changed, provide those certain values as the second argument.
-  *
-  * @see
-  *   https://reactjs.org/docs/hooks-reference.html#useLayoutEffect
-  */
+    * The signature is identical to [[useEffect]], but it fires synchronously after all DOM mutations.
+    * Use this to read layout from the DOM and synchronously re-render. Updates scheduled inside
+    * useLayoutEffect will be flushed synchronously, before the browser has a chance to paint.
+    *
+    * Prefer the standard [[useEffect]] when possible to avoid blocking visual updates.
+    *
+    * If you'd only like to execute the effect when your component is mounted, then use
+    * [[useLayoutEffectOnMount]]. If you'd only like to execute the effect when certain values have
+    * changed, provide those certain values as the second argument.
+    *
+    * @see
+    *   https://reactjs.org/docs/hooks-reference.html#useLayoutEffect
+    */
   @inline final def useLayoutEffect[A](effect: A)(implicit isEffectArg: UseEffectArg[A]): HookResult[Unit] =
     HookResult(UseEffect.unsafeCreateLayout(effect))
 
   /**
-  * The signature is identical to [[useEffect]], but it fires synchronously after all DOM mutations.
-  * Use this to read layout from the DOM and synchronously re-render. Updates scheduled inside
-  * useLayoutEffect will be flushed synchronously, before the browser has a chance to paint.
-  *
-  * Prefer the standard [[useEffect]] when possible to avoid blocking visual updates.
-  *
-  * This will only execute the effect when your component is mounted.
-  *
-  * @see
-  *   https://reactjs.org/docs/hooks-reference.html#useLayoutEffect
-  */
+    * The signature is identical to [[useEffect]], but it fires synchronously after all DOM mutations.
+    * Use this to read layout from the DOM and synchronously re-render. Updates scheduled inside
+    * useLayoutEffect will be flushed synchronously, before the browser has a chance to paint.
+    *
+    * Prefer the standard [[useEffect]] when possible to avoid blocking visual updates.
+    *
+    * This will only execute the effect when your component is mounted.
+    *
+    * @see
+    *   https://reactjs.org/docs/hooks-reference.html#useLayoutEffect
+    */
   @inline final def useLayoutEffectOnMount[A](effect: A)(implicit isEffectArg: UseEffectArg[A]): HookResult[Unit] =
     HookResult(UseEffect.unsafeCreateLayoutOnMount(effect))
 
   /**
-  * The signature is identical to [[useEffect]], but it fires synchronously after all DOM mutations.
-  * Use this to read layout from the DOM and synchronously re-render. Updates scheduled inside
-  * useLayoutEffect will be flushed synchronously, before the browser has a chance to paint.
-  *
-  * Prefer the standard [[useEffect]] when possible to avoid blocking visual updates.
-  *
-  * This will only execute the effect when values in the second argument, change.
-  *
-  * @see
-  *   https://reactjs.org/docs/hooks-reference.html#useLayoutEffect
-  */
+    * The signature is identical to [[useEffect]], but it fires synchronously after all DOM mutations.
+    * Use this to read layout from the DOM and synchronously re-render. Updates scheduled inside
+    * useLayoutEffect will be flushed synchronously, before the browser has a chance to paint.
+    *
+    * Prefer the standard [[useEffect]] when possible to avoid blocking visual updates.
+    *
+    * This will only execute the effect when values in the second argument, change.
+    *
+    * @see
+    *   https://reactjs.org/docs/hooks-reference.html#useLayoutEffect
+    */
   @inline final def useLayoutEffectWithDeps[D: Reusability, A](deps: => D)(effect: D => A)(
     implicit isEffectArg: UseEffectArg[A]
   ): HookResult[Unit] =
     ReusableEffect.useLayoutEffect(deps)(effect).toHookResult
 
   /**
-  * Returns a memoized value.
-  *
-  * Pass a “create” function and any dependencies. useMemo will only recompute the memoized value
-  * when one of the dependencies has changed. This optimization helps to avoid expensive calculations
-  * on every render.
-  *
-  * Remember that the function passed to useMemo runs during rendering. Don’t do anything there that
-  * you wouldn’t normally do while rendering. For example, side effects belong in [[useEffect]], not
-  * useMemo.
-  *
-  * @see
-  *   https://reactjs.org/docs/hooks-reference.html#usememo
-  */
+    * Returns a memoized value.
+    *
+    * Pass a “create” function and any dependencies. useMemo will only recompute the memoized value
+    * when one of the dependencies has changed. This optimization helps to avoid expensive calculations
+    * on every render.
+    *
+    * Remember that the function passed to useMemo runs during rendering. Don’t do anything there that
+    * you wouldn’t normally do while rendering. For example, side effects belong in [[useEffect]], not
+    * useMemo.
+    *
+    * @see
+    *   https://reactjs.org/docs/hooks-reference.html#usememo
+    */
   @inline final def useMemo[D: Reusability, A](deps: => D)(create: D => A): HookResult[Reusable[A]] =
     UseMemo(deps)(create).toHookResult
 
   /**
-  * An alternative to [[useState]]. Accepts a reducer of type `(state, action) => newState`, and
-  * returns the current state paired with a dispatch method. (If you’re familiar with Redux, you
-  * already know how this works.)
-  *
-  * useReducer is usually preferable to useState when you have complex state logic that involves
-  * multiple sub-values or when the next state depends on the previous one. useReducer also lets you
-  * optimize performance for components that trigger deep updates because you can pass dispatch down
-  * instead of callbacks.
-  *
-  * @see
-  *   https://reactjs.org/docs/hooks-reference.html#usereducer
-  */
+    * An alternative to [[useState]]. Accepts a reducer of type `(state, action) => newState`, and
+    * returns the current state paired with a dispatch method. (If you’re familiar with Redux, you
+    * already know how this works.)
+    *
+    * useReducer is usually preferable to useState when you have complex state logic that involves
+    * multiple sub-values or when the next state depends on the previous one. useReducer also lets you
+    * optimize performance for components that trigger deep updates because you can pass dispatch down
+    * instead of callbacks.
+    *
+    * @see
+    *   https://reactjs.org/docs/hooks-reference.html#usereducer
+    */
   @inline final def useReducer[S, A](reducer: (S, A) => S, initialState: => S): HookResult[UseReducer[S, A]] =
     HookResult(UseReducer.unsafeCreate(reducer, initialState))
 
@@ -193,14 +193,14 @@ trait react17 {
     HookResult(UseRef.unsafeCreate(initialValue))
 
   /**
-  * Returns a stateful value, and a function to update it.
-  *
-  * During the initial render, the returned state is the same as the value passed as the first
-  * argument (initialState).
-  *
-  * During subsequent re-renders, the first value returned by useState will always be the most recent
-  * state after applying updates.
-  */
+    * Returns a stateful value, and a function to update it.
+    *
+    * During the initial render, the returned state is the same as the value passed as the first
+    * argument (initialState).
+    *
+    * During subsequent re-renders, the first value returned by useState will always be the most recent
+    * state after applying updates.
+    */
   @inline final def useState[A](initial: => A): HookResult[UseState[A]] =
     HookResult(UseState.unsafeCreate(initial))
 }

--- a/library/coreGeneric/src/main/scala/japgolly/scalajs/react/hooks/react18.scala
+++ b/library/coreGeneric/src/main/scala/japgolly/scalajs/react/hooks/react18.scala
@@ -3,6 +3,7 @@ package japgolly.scalajs.react.hooks
 import japgolly.scalajs.react.hooks.Hooks._
 import japgolly.scalajs.react.util.Effect.Sync
 import scala.scalajs.js
+import japgolly.scalajs.react.Reusability
 
 trait react18 {
   /**
@@ -36,4 +37,52 @@ trait react18 {
     */
   @inline final def useSyncExternalStore[F[_], A](subscribe: F[Unit] => F[F[Unit]], getSnapshot: F[A], getServerSnapshot: js.UndefOr[F[A]] = js.undefined)(implicit F: Sync[F]): HookResult[A] =
     UseSyncExternalStore(subscribe, getSnapshot, getServerSnapshot).toHookResult
+
+
+  /** The signature is identical to [[useEffect]], but it fires synchronously after all DOM mutations, but before any 
+    * layout Effects fire. Use this to insert styles before any Effects fire that may need to read layout. Updates 
+    * scheduled inside useLayoutEffect will be flushed synchronously, before the browser has a chance to paint.
+    *
+    * Prefer the standard [[useEffect]] when possible to avoid blocking visual updates.
+    *
+    * If you'd only like to execute the effect when your component is mounted, then use [[useInsertionEffectOnMount]].
+    * If you'd only like to execute the effect when certain values have changed, provide those certain values as
+    * the first argument.
+    *
+    * @see https://react.dev/reference/react/useInsertionEffect#useInsertionEffect
+    */
+  @inline final def useInsertionEffect[A](effect: A)(implicit isEffectArg: UseEffectArg[A]): HookResult[Unit] =
+    HookResult(UseEffect.unsafeCreateInsertion(effect))
+
+  /** The signature is identical to [[useEffect]], but it fires synchronously after all DOM mutations, but before any 
+    * layout Effects fire. Use this to insert styles before any Effects fire that may need to read layout. Updates 
+    * scheduled inside useLayoutEffect will be flushed synchronously, before the browser has a chance to paint.
+    *
+    * Prefer the standard [[useEffect]] when possible to avoid blocking visual updates.
+    *
+    * If you'd only like to execute the effect when your component is mounted, then use [[useInsertionEffectOnMount]].
+    * If you'd only like to execute the effect when certain values have changed, provide those certain values as
+    * the first argument.
+    *
+    * @see https://react.dev/reference/react/useInsertionEffect#useInsertionEffect
+    */
+  @inline final def useInsertionEffectOnMount[A](effect: A)(implicit isEffectArg: UseEffectArg[A]): HookResult[Unit] =
+    HookResult(UseEffect.unsafeCreateInsertionOnMount(effect))
+
+  /** The signature is identical to [[useEffect]], but it fires synchronously after all DOM mutations, but before any 
+    * layout Effects fire. Use this to insert styles before any Effects fire that may need to read layout. Updates 
+    * scheduled inside useLayoutEffect will be flushed synchronously, before the browser has a chance to paint.
+    *
+    * Prefer the standard [[useEffect]] when possible to avoid blocking visual updates.
+    *
+    * If you'd only like to execute the effect when your component is mounted, then use [[useInsertionEffectOnMount]].
+    * If you'd only like to execute the effect when certain values have changed, provide those certain values as
+    * the first argument.
+    *
+    * @see https://react.dev/reference/react/useInsertionEffect#useInsertionEffect
+    */
+  @inline final def useInsertionEffectWithDeps[D: Reusability, A](deps: => D)(effect: D => A)(
+    implicit isEffectArg: UseEffectArg[A]
+  ): HookResult[Unit] =
+    ReusableEffect.useInsertionEffect(deps)(effect).toHookResult
 }

--- a/library/coreGeneric/src/main/scala/japgolly/scalajs/react/hooks/react18.scala
+++ b/library/coreGeneric/src/main/scala/japgolly/scalajs/react/hooks/react18.scala
@@ -51,8 +51,7 @@ trait react18 {
     * Prefer the standard [[useEffect]] when possible to avoid blocking visual updates.
     *
     * If you'd only like to execute the effect when your component is mounted, then use [[useInsertionEffectOnMount]].
-    * If you'd only like to execute the effect when certain values have changed, provide those certain values as
-    * the first argument.
+    * If you'd only like to execute the effect when certain values have changed, then use [[useInsertionEffectWithDeps]].
     *
     * @see https://react.dev/reference/react/useInsertionEffect#useInsertionEffect
     */
@@ -65,9 +64,7 @@ trait react18 {
     *
     * Prefer the standard [[useEffect]] when possible to avoid blocking visual updates.
     *
-    * If you'd only like to execute the effect when your component is mounted, then use [[useInsertionEffectOnMount]].
-    * If you'd only like to execute the effect when certain values have changed, provide those certain values as
-    * the first argument.
+    * This will only execute the effect when your component is mounted.
     *
     * @see https://react.dev/reference/react/useInsertionEffect#useInsertionEffect
     */
@@ -80,9 +77,7 @@ trait react18 {
     *
     * Prefer the standard [[useEffect]] when possible to avoid blocking visual updates.
     *
-    * If you'd only like to execute the effect when your component is mounted, then use [[useInsertionEffectOnMount]].
-    * If you'd only like to execute the effect when certain values have changed, provide those certain values as
-    * the first argument.
+    * This will only execute the effect when values in the first argument change.
     *
     * @see https://react.dev/reference/react/useInsertionEffect#useInsertionEffect
     */

--- a/library/coreGeneric/src/main/scala/japgolly/scalajs/react/hooks/react18.scala
+++ b/library/coreGeneric/src/main/scala/japgolly/scalajs/react/hooks/react18.scala
@@ -1,9 +1,10 @@
 package japgolly.scalajs.react.hooks
 
+import japgolly.scalajs.react.Reusability
+import japgolly.scalajs.react.hooks.HookResult
 import japgolly.scalajs.react.hooks.Hooks._
 import japgolly.scalajs.react.util.Effect.Sync
 import scala.scalajs.js
-import japgolly.scalajs.react.Reusability
 
 trait react18 {
   /**
@@ -35,7 +36,11 @@ trait react18 {
     * @see
     *   {@link https://react.dev/reference/react/useSyncExternalStore}
     */
-  @inline final def useSyncExternalStore[F[_], A](subscribe: F[Unit] => F[F[Unit]], getSnapshot: F[A], getServerSnapshot: js.UndefOr[F[A]] = js.undefined)(implicit F: Sync[F]): HookResult[A] =
+  @inline final def useSyncExternalStore[F[_], A](
+    subscribe: F[Unit] => F[F[Unit]],
+    getSnapshot: F[A],
+    getServerSnapshot: js.UndefOr[F[A]] = js.undefined
+  )(implicit F: Sync[F]): HookResult[A] =
     UseSyncExternalStore(subscribe, getSnapshot, getServerSnapshot).toHookResult
 
 
@@ -85,4 +90,16 @@ trait react18 {
     implicit isEffectArg: UseEffectArg[A]
   ): HookResult[Unit] =
     ReusableEffect.useInsertionEffect(deps)(effect).toHookResult
+
+  /**
+    * Lets you defer updating a part of the UI.
+    *
+    * @see
+    *   {@link https://react.dev/reference/react/useDeferredValue}
+    */
+  // initialValue was added in React 19 - Replace when we upgrade to React 19
+  // @inline final def useDeferredValue[A](value: A, initialValue: js.UndefOr[A] = js.undefined): HookResult[A] =
+  //   UseDeferredValue(value, initialValue).toHookResult
+  @inline final def useDeferredValue[A](value: A): HookResult[A] =
+    UseDeferredValue(value).toHookResult
 }

--- a/library/coreGeneric/src/main/scala/japgolly/scalajs/react/hooks/react18.scala
+++ b/library/coreGeneric/src/main/scala/japgolly/scalajs/react/hooks/react18.scala
@@ -1,10 +1,12 @@
 package japgolly.scalajs.react.hooks
 
 import japgolly.scalajs.react.hooks.Hooks._
+import japgolly.scalajs.react.util.Effect.Sync
+import scala.scalajs.js
 
 trait react18 {
   /**
-  * `useId` is a React Hook for generating unique IDs that can be passed to accessibility attributes.
+  * Generates unique IDs that can be passed to accessibility attributes.
   *
   * @see
   *   https://react.dev/reference/react/useId
@@ -25,4 +27,13 @@ trait react18 {
   */
   @inline final def useTransition: HookResult[UseTransition] =
     UseTransition().toHookResult
+
+  /**
+    * Lets you subscribe to an external store.
+    *
+    * @see
+    *   {@link https://react.dev/reference/react/useSyncExternalStore}
+    */
+  @inline final def useSyncExternalStore[F[_], A](subscribe: F[Unit] => F[F[Unit]], getSnapshot: F[A], getServerSnapshot: js.UndefOr[F[A]] = js.undefined)(implicit F: Sync[F]): HookResult[A] =
+    UseSyncExternalStore(subscribe, getSnapshot, getServerSnapshot).toHookResult
 }

--- a/library/facadeMain/src/main/scala/japgolly/scalajs/react/facade/Hooks.scala
+++ b/library/facadeMain/src/main/scala/japgolly/scalajs/react/facade/Hooks.scala
@@ -61,5 +61,7 @@ trait Hooks extends js.Object {
     getServerSnapshot: js.UndefOr[js.Function0[A]] = js.undefined
   ): A = js.native
 
-  final def useDeferredValue[A](value: A, config: js.UndefOr[A] = js.undefined): A = js.native
+  // initialValue was added in React 19 - Replace when we upgrade to React 19
+  // final def useDeferredValue[A](value: A, initialValue: js.UndefOr[A] = js.undefined): A = js.native
+  final def useDeferredValue[A](value: A): A = js.native
 }

--- a/library/facadeMain/src/main/scala/japgolly/scalajs/react/facade/Hooks.scala
+++ b/library/facadeMain/src/main/scala/japgolly/scalajs/react/facade/Hooks.scala
@@ -1,6 +1,5 @@
 package japgolly.scalajs.react.facade
 
-import scala.annotation.nowarn
 import scala.scalajs.js
 import scala.scalajs.js.|
 
@@ -9,7 +8,6 @@ import scala.scalajs.js.|
   * @since React 16.8.0 / scalajs-react 2.0.0
   */
 @js.native
-@nowarn("cat=unused")
 trait Hooks extends js.Object {
 
   final type HookDeps = js.UndefOr[js.Array[_]] | Null
@@ -27,6 +25,9 @@ trait Hooks extends js.Object {
 
   final def useLayoutEffect(effect: js.Function0[js.UndefOr[js.Function0[Any]]],
                             deps  : js.UndefOr[HookDeps] = js.native): Unit = js.native
+
+  final def useInsertionEffect(effect: js.Function0[js.UndefOr[js.Function0[Any]]],
+                               deps  : js.UndefOr[HookDeps] = js.native): Unit = js.native
 
   final def useContext[A](ctx: React.Context[A]): A = js.native
 
@@ -52,4 +53,13 @@ trait Hooks extends js.Object {
   final def useId(): String = js.native
 
   final def useTransition(): UseTransition = js.native
+
+  final type UseSyncExternalStoreSubscribeArg = js.Function1[js.Function0[Unit], js.Function0[Unit]]
+  final def useSyncExternalStore[A](
+    subscribe: UseSyncExternalStoreSubscribeArg,
+    getSnapshot: js.Function0[A],
+    getServerSnapshot: js.UndefOr[js.Function0[A]] = js.undefined
+  ): A = js.native
+
+  final def useDeferredValue[A](value: A, config: js.UndefOr[A] = js.undefined): A = js.native
 }

--- a/library/facadeMain/src/main/scala/japgolly/scalajs/react/facade/React.scala
+++ b/library/facadeMain/src/main/scala/japgolly/scalajs/react/facade/React.scala
@@ -180,7 +180,6 @@ object React extends React {
 }
 
 @js.native
-@nowarn("cat=unused")
 trait React extends Hooks {
   import React._
 

--- a/library/project/GenHooks.scala
+++ b/library/project/GenHooks.scala
@@ -58,6 +58,13 @@ object GenHooks {
            |      z => ($as) => Z.dispatch(z($as)))(
            |      z => Reusable.byRef(z).withValue(($as) => Z.delay(z($as))))
            |""".stripMargin
+           
+      useCallbackArgs +=
+        s"""  implicit def ci$n[$As, Y, Z[_]](implicit Z: UnsafeSync[Z]): UseCallbackArg[($As) => Z[Y]] =
+           |    UseCallbackArg[($As) => Z[Y], js.Function$n[$As, Y]](
+           |      z => ($as) => Z.runSync(z($as)))(
+           |      z => Reusable.byRef(z).withValue(($as) => Z.delay(z($as))))
+           |""".stripMargin
 
       if (n <= 21) {
         hookCtxCtorsI += s"    def apply[I, $Hns](input: I, $hookParams): I$n[I, $Hns] =\n      new I$n(input, $hookArgs)"


### PR DESCRIPTION
Implements:
- `useDeferredValue`
- `useSyncExternalStore`
- `useInsertionEffect`

`useCallback` now accepts functions that return a sync value (before it only worked on functions that returned sync or async `Unit`).

