### PR TITLE
Update act

### DIFF
--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -32,7 +32,7 @@ for how to write tests for real-world scalajs-react applications.
    // NOTE: Requires react-with-addons.js instead of just react.js
    jsDependencies +=
 
-     "org.webjars.npm" % "react-dom" % "18.2.0" % Test
+     "org.webjars.npm" % "react-dom" % "18.3.1" % Test
        /         "umd/react-dom-test-utils.development.js"
        minified  "umd/react-dom-test-utils.production.min.js"
        dependsOn "umd/react-dom.development.js"

--- a/doc/USAGE.md
+++ b/doc/USAGE.md
@@ -44,34 +44,34 @@ libraryDependencies += "com.github.japgolly.scalajs-react" %%% "core" % "2.1.1"
      libraryDependencies += "com.github.japgolly.scalajs-react" %%% "core" % "2.1.1"
 
      Compile / npmDependencies ++= Seq(
-       "react" -> "18.2.0",
-       "react-dom" -> "18.2.0")
+       "react" -> "18.3.1",
+       "react-dom" -> "18.3.1")
    ```
 
    If you're using `jsDependencies`, add the following:
 
    ```scala
-   // Required for React 18.2.0
+   // Required for React 18.3.1
    dependencyOverrides += "org.webjars.npm" % "scheduler" % "0.22.0",
 
    jsDependencies ++= Seq(
 
-     // Polyfill required for React 18.2.0
+     // Polyfill required for React 18.3.1
      "org.webjars.npm" % "fast-text-encoding" % "1.0.3" / "text.js" minified "text.min.js"
 
-     "org.webjars.npm" % "react" % "18.2.0"
+     "org.webjars.npm" % "react" % "18.3.1"
        /         "umd/react.development.js"
        minified  "umd/react.production.min.js"
        dependsOn "text.js" // <-- Load the fast-text-encoding polyfill before loading React itself
        commonJSName "React",
 
-     "org.webjars.npm" % "react-dom" % "18.2.0"
+     "org.webjars.npm" % "react-dom" % "18.3.1"
        /         "umd/react-dom.development.js"
        minified  "umd/react-dom.production.min.js"
        dependsOn "umd/react.development.js"
        commonJSName "ReactDOM",
 
-     "org.webjars.npm" % "react-dom" % "18.2.0"
+     "org.webjars.npm" % "react-dom" % "18.3.1"
        /         "umd/react-dom-server.browser.development.js"
        minified  "umd/react-dom-server.browser.production.min.js"
        dependsOn "umd/react-dom.development.js"

--- a/doc/changelog/3.0.0-betas.md
+++ b/doc/changelog/3.0.0-betas.md
@@ -26,26 +26,26 @@
 - To upgrade when using `jsDependencies`, make your sbt config look like this (comments for clarity)
 
   ```scala
-  // Required for React 18.2.0
+  // Required for React 18.3.1
   dependencyOverrides += "org.webjars.npm" % "scheduler" % "0.22.0",
 
   jsDependencies ++= Seq(
-    // Polyfill required for React 18.2.0
+    // Polyfill required for React 18.3.1
     "org.webjars.npm" % "fast-text-encoding" % "1.0.6" / "text.min.js" minified "text.min.js"
 
-    "org.webjars.npm" % "react" % "18.2.0"
+    "org.webjars.npm" % "react" % "18.3.1"
       /         "umd/react.development.js"
       minified  "umd/react.production.min.js"
       dependsOn "text.min.js" // <-- Load the fast-text-encoding polyfill before loading React itself
       commonJSName "React",
 
-    "org.webjars.npm" % "react-dom" % "18.2.0"
+    "org.webjars.npm" % "react-dom" % "18.3.1"
       /         "umd/react-dom.development.js"
       minified  "umd/react-dom.production.min.js"
       dependsOn "umd/react.development.js"
       commonJSName "ReactDOM",
 
-    "org.webjars.npm" % "react-dom" % "18.2.0"
+    "org.webjars.npm" % "react-dom" % "18.3.1"
       /         "umd/react-dom-server.browser.development.js"
       minified  "umd/react-dom-server.browser.production.min.js"
       dependsOn "umd/react-dom.development.js"

--- a/library/facadeMain/src/main/scala/japgolly/scalajs/react/facade/Act.scala
+++ b/library/facadeMain/src/main/scala/japgolly/scalajs/react/facade/Act.scala
@@ -1,0 +1,41 @@
+package japgolly.scalajs.react.facade
+
+import scalajs.js
+import scalajs.js.annotation.JSName
+
+/** 
+  * @since React 18.3.0 / scalajs-react 3.0.0
+  */
+@js.native
+trait Act extends js.Object {
+  /** When writing UI tests, tasks like rendering, user events, or data fetching can be considered as "units" of
+    * interaction with a user interface. React provides a helper called act() that makes sure all updates related to
+    * these "units" have been processed and applied to the DOM before you make any assertions:
+    *
+    * {{{
+    *   act(() => {
+    *     // render components
+    *   });
+    *   // make assertions
+    * }}}
+    *
+    * This helps make your tests run closer to what real users would experience when using your application.
+    */
+  final def act(body: js.Function0[Any]): js.Thenable[Unit] = js.native
+
+/** When writing UI tests, tasks like rendering, user events, or data fetching can be considered as "units" of
+  * interaction with a user interface. React provides a helper called act() that makes sure all updates related to
+  * these "units" have been processed and applied to the DOM before you make any assertions:
+  *
+  * {{{
+  *   await act(async () => {
+  *     // render components
+  *   });
+  *   // make assertions
+  * }}}
+  *
+  * This helps make your tests run closer to what real users would experience when using your application.
+  */
+  @JSName("act")
+  final def actAsync[A](body: js.Function0[js.Thenable[A]]): js.Thenable[A] = js.native
+}

--- a/library/facadeMain/src/main/scala/japgolly/scalajs/react/facade/React.scala
+++ b/library/facadeMain/src/main/scala/japgolly/scalajs/react/facade/React.scala
@@ -180,7 +180,7 @@ object React extends React {
 }
 
 @js.native
-trait React extends Hooks {
+trait React extends Hooks with Act {
   import React._
 
   final def createContext[A](defaultValue: A): React.Context[A] = js.native

--- a/library/facadeTest/src/main/scala/japgolly/scalajs/react/test/facade/ReactTestUtils.scala
+++ b/library/facadeTest/src/main/scala/japgolly/scalajs/react/test/facade/ReactTestUtils.scala
@@ -12,7 +12,6 @@ import scala.scalajs.js.|
 object ReactTestUtils extends ReactTestUtils
 
 @js.native
-@nowarn("cat=unused")
 trait ReactTestUtils extends js.Object {
 
   final val Simulate: Simulate = js.native
@@ -30,6 +29,7 @@ trait ReactTestUtils extends js.Object {
     *
     * This helps make your tests run closer to what real users would experience when using your application.
     */
+  @deprecated("Use React.act", "3.0.0")
   final def act(body: js.Function0[Any]): js.Thenable[Unit] = js.native
 
   /** When writing UI tests, tasks like rendering, user events, or data fetching can be considered as "units" of
@@ -46,6 +46,7 @@ trait ReactTestUtils extends js.Object {
     * This helps make your tests run closer to what real users would experience when using your application.
     */
   @JSName("act")
+  @deprecated("Use React.actAsync", "3.0.0")
   final def actAsync(body: js.Function0[js.Thenable[Any]]): js.Thenable[Unit] = js.native
 
   /** Render a component into a detached DOM node in the document. This function requires a DOM. */

--- a/library/ghpages/html/dev2.html
+++ b/library/ghpages/html/dev2.html
@@ -3,8 +3,8 @@
 <head lang="en">
     <meta charset="UTF-8">
     <title></title>
-    <script src="https://unpkg.com/react@18.2.0/umd/react.development.js"></script>
-    <script src="https://unpkg.com/react-dom@18.2.0/umd/react-dom.development.js"></script>
+    <script src="https://unpkg.com/react@18.3.1/umd/react.development.js"></script>
+    <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/scala.min.js"></script>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/monokai-sublime.min.css">

--- a/library/ghpages/html/dev3.html
+++ b/library/ghpages/html/dev3.html
@@ -3,8 +3,8 @@
 <head lang="en">
     <meta charset="UTF-8">
     <title></title>
-    <script src="https://unpkg.com/react@18.2.0/umd/react.development.js"></script>
-    <script src="https://unpkg.com/react-dom@18.2.0/umd/react-dom.development.js"></script>
+    <script src="https://unpkg.com/react@18.3.1/umd/react.development.js"></script>
+    <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/scala.min.js"></script>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/monokai-sublime.min.css">

--- a/library/ghpages/html/prod.html
+++ b/library/ghpages/html/prod.html
@@ -3,8 +3,8 @@
 <head lang="en">
     <meta charset="UTF-8">
     <title></title>
-    <script crossorigin src="https://unpkg.com/react@18.2.0/umd/react.production.min.js"></script>
-    <script crossorigin src="https://unpkg.com/react-dom@18.2.0/umd/react-dom.production.min.js"></script>
+    <script crossorigin src="https://unpkg.com/react@18.3.1/umd/react.production.min.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js"></script>
     <script crossorigin src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
     <script crossorigin src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/scala.min.js"></script>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/monokai-sublime.min.css">

--- a/library/project/Dependencies.scala
+++ b/library/project/Dependencies.scala
@@ -27,7 +27,7 @@ object Dependencies {
     val kindProjector         = "0.13.3"
     val macrotaskExecutor     = "1.1.1"
     val nyaya                 = "1.0.0"
-    val reactJs               = "18.2.0"
+    val reactJs               = "18.3.1"
     val scalaJsJavaTime       = "1.0.0"
     val scalaJsSecureRandom   = "1.0.0"
     val scalaTest             = "3.2.11"
@@ -83,7 +83,7 @@ object Dependencies {
     Dep.scalaJsDom.value,
     Dep.univEq.value,
     Dep.univEqCats.value,
-    "org.webjars.npm" % "scheduler" % "0.22.0", // Required for React 18.2.0
+    "org.webjars.npm" % "scheduler" % "0.22.0", // Required for React 18.3.1
   ))
 
   final case class ReactArtifact(filename: String) {

--- a/library/testUtil/src/main/scala/japgolly/scalajs/react/test/ReactTestUtils2.scala
+++ b/library/testUtil/src/main/scala/japgolly/scalajs/react/test/ReactTestUtils2.scala
@@ -129,4 +129,12 @@ trait ReactTestUtils2 extends japgolly.scalajs.react.test.internal.ReactTestUtil
     F.flatMap(F.pure(ReactTestUtils2.withReactRoot.setup(implicitly, new WithDsl.Cleanup)))(
       root => F.map(actAsync(root.render(unmounted)))(_ => root.selectFirstChild())
     )
+
+  def withRenderedAsync[F[_], A](
+    unmounted: A
+  )(use: TestDomWithRoot => F[Unit]
+  )(implicit F: Async[F], renderable: Renderable[A]): F[Unit] =
+    F.flatMap(renderAsync(unmounted)) { d =>
+      F.finallyRun(use(d), actAsync(d.unmount()))
+    }
 }

--- a/library/testUtil/src/main/scala/japgolly/scalajs/react/test/internal/WithDsl.scala
+++ b/library/testUtil/src/main/scala/japgolly/scalajs/react/test/internal/WithDsl.scala
@@ -98,7 +98,7 @@ trait WithDsl[A, I] { self =>
   def map[B](f: A => B): WithDsl[B, I] =
     mapFull { (a, _) => f(a) }
 
-  def mapResourse[B](f: A => B)(cleanup: B => Unit): WithDsl[B, I] =
+  def mapResource[B](f: A => B)(cleanup: B => Unit): WithDsl[B, I] =
     mapFull { (a, c) =>
       val b = f(a)
       c.register(cleanup(b))


### PR DESCRIPTION
Starting in React 18.3, `act` has been moved to `React` and deprecated in `ReactTestUtils`.

Also, this PR implements 3 methods in `ReactTestUtils2`:
- `renderAsync`, which invokes `act(root.render(component))` asnychronouslly;
- `actAsync(=> A)` which is a convenience method for async `act` without the need of wrapping the action in an async effect;
- `withRenderedAsync`, which is an async version of `withRendered`.

This enables async testing with the pattern:
```scala
withRenderedAsync(comp()){ _ =>  // Mounts comp in root
  assert(...)
  for
    _ <- actAsync(Simulate.click(...))
    _ =  assert(...)
    _ <- actAsync(Simulate.click(...))
  yield assert(...)
}.map(_ => assert(...))          // After unmount
```

`act` will become fully async in the future. The current React docs read:
```
We recommend using act with await and an async function. Although the sync version works in many cases, it doesn’t work in all cases and due to the way React schedules updates internally, it’s difficult to predict when you can use the sync version.

We will deprecate and remove the sync version in the future.
```

Note: This PR subsumes https://github.com/japgolly/scalajs-react/pull/1105, since React 18.3 is needed.