### PR TITLE
Modernize tests

### DIFF
--- a/downstream-tests/build.sbt
+++ b/downstream-tests/build.sbt
@@ -1,3 +1,4 @@
+import Dependencies.Dep.utest
 import java.util.Properties
 import org.scalajs.linker.interface._
 import Dependencies._
@@ -69,6 +70,8 @@ def commonSettings: Project => Project = _
 lazy val cleanTestAll = taskKey[Unit]("cleanTestAll")
 
 val enableJSCE = System.getProperty("downstream_tests.enableJSCE") != null
+
+val utestCE = Def.setting("org.typelevel" %%% "cats-effect-testing-utest" % "1.6.0" % Test)
 
 lazy val root = Project("root", file("."))
   .configure(commonSettings)
@@ -161,11 +164,14 @@ lazy val js = project
         Dep.scalaJsSecureRandom.value % Test,
       )
     },
+    jsDependencies ++= Seq(
+      (ProvidedJS / "polyfill.js") % Test
+    ),
     scalaJSLinkerConfig ~= { _
       .withSemantics(_
         .withRuntimeClassNameMapper(Semantics.RuntimeClassNameMapper.discardAll())
       )
-    },
+    }
   )
 
 lazy val jsCE = project
@@ -181,12 +187,16 @@ lazy val jsCE = project
         "com.github.japgolly.scalajs-react" %%% "core-bundle-cats_effect" % ver,
         "com.github.japgolly.scalajs-react" %%% "extra" % ver,
         "com.github.japgolly.scalajs-react" %%% "test" % ver % Test,
+        utestCE.value,
         Dep.microlibsCompileTime.value % Test,
         Dep.microlibsTestUtil.value % Test,
         Dep.scalaJsJavaTime.value % Test,
         Dep.scalaJsSecureRandom.value % Test,
       )
     },
+    jsDependencies ++= Seq(
+      (ProvidedJS / "polyfill.js") % Test
+    ),
   )
 
 lazy val jsCBIO = project
@@ -202,13 +212,18 @@ lazy val jsCBIO = project
         "com.github.japgolly.scalajs-react" %%% "core-bundle-cb_io" % ver,
         "com.github.japgolly.scalajs-react" %%% "extra" % ver,
         "com.github.japgolly.scalajs-react" %%% "test" % ver % Test,
+        utestCE.value,
         Dep.microlibsCompileTime.value % Test,
         Dep.microlibsTestUtil.value % Test,
         Dep.scalaJsJavaTime.value % Test,
         Dep.scalaJsSecureRandom.value % Test,
       )
     },
+    jsDependencies ++= Seq(
+      (ProvidedJS / "polyfill.js") % Test
+    ),
   )
+  
 
 lazy val generic = project
   .enablePlugins(ScalaJSPlugin)

--- a/downstream-tests/flake.nix
+++ b/downstream-tests/flake.nix
@@ -1,0 +1,43 @@
+{
+  inputs = {
+    typelevel-nix.url = "github:typelevel/typelevel-nix";
+    nixpkgs.follows = "typelevel-nix/nixpkgs";
+    flake-utils.follows = "typelevel-nix/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, typelevel-nix }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs-x86_64 = import nixpkgs { system = "x86_64-darwin"; };
+        scala-cli-overlay = final: prev: { scala-cli = pkgs-x86_64.scala-cli; };
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ typelevel-nix.overlays.default scala-cli-overlay];
+        };
+      in
+      {
+        devShell = pkgs.devshell.mkShell {
+          imports = [ typelevel-nix.typelevelShell ];
+          packages = [
+            pkgs.nodePackages.typescript-language-server
+            pkgs.nodePackages.vscode-langservers-extracted
+            pkgs.nodePackages.prettier
+            pkgs.nodePackages.typescript
+            pkgs.nodePackages.graphqurl
+            pkgs.hasura-cli
+          ];
+          typelevelShell = {
+            nodejs.enable = true;
+            jdk.package = pkgs.jdk11;
+          };
+          env = [
+            {
+              name = "NODE_OPTIONS";
+              value = "--max-old-space-size=8192";
+            }
+          ];
+        };
+      }
+
+    );
+}

--- a/downstream-tests/js-cbio/src/test/resources/polyfill.js
+++ b/downstream-tests/js-cbio/src/test/resources/polyfill.js
@@ -2,5 +2,3 @@ const outerRealmFunctionConstructor = Node.constructor;
 window.require = new outerRealmFunctionConstructor("return require")();
 
 window.MessageChannel = require('worker_threads').MessageChannel;
-
-window.scrollTo = function () { }

--- a/downstream-tests/js-cbio/src/test/scala/downstream/CBIOBundleTests.scala
+++ b/downstream-tests/js-cbio/src/test/scala/downstream/CBIOBundleTests.scala
@@ -22,7 +22,7 @@ object CBIOBundleTests extends TestSuite {
     Globals.clear()
 
     "catnip" - {
-      ReactTestUtils2.withRendered(Catnip.Component("omg")).future { m =>
+      ReactTestUtils2.withRenderedSync(Catnip.Component("omg")).future { m =>
         delay(500).map { _ =>
           assertEq(Globals.catnipMounts, List("omg"))
           m.outerHTML.assert("<div>Hello(1) omg</div>")

--- a/downstream-tests/js-cbio/src/test/scala/downstream/CBIOBundleTests.scala
+++ b/downstream-tests/js-cbio/src/test/scala/downstream/CBIOBundleTests.scala
@@ -1,29 +1,20 @@
 package downstream
 
-import concurrent.ExecutionContext.Implicits.global
 import japgolly.microlibs.testutil.TestUtil._
 import japgolly.scalajs.react.test.ReactTestUtils2
-import scala.concurrent.Future
-import scala.concurrent.Promise
-import scalajs.js
 import utest._
+import cats.effect.testing.utest.EffectTestSuite
+import cats.effect.IO
+import scala.concurrent.duration._
 
-object CBIOBundleTests extends TestSuite {
-
-  private def delay(milliseconds: Int): Future[Unit] = {
-    val p = Promise[Unit]()
-    js.timers.setTimeout(milliseconds) {
-      p.success(())
-    }
-    p.future
-  }
+object CBIOBundleTests extends EffectTestSuite[IO] {
 
   override def tests = Tests {
     Globals.clear()
 
     "catnip" - {
-      ReactTestUtils2.withRenderedSync(Catnip.Component("omg")).future { m =>
-        delay(500).map { _ =>
+      ReactTestUtils2.withRendered(Catnip.Component("omg")) { m =>
+        IO.sleep(500.millis).map { _ =>
           assertEq(Globals.catnipMounts, List("omg"))
           m.outerHTML.assert("<div>Hello(1) omg</div>")
         }

--- a/downstream-tests/js-ce/src/test/resources/polyfill.js
+++ b/downstream-tests/js-ce/src/test/resources/polyfill.js
@@ -2,5 +2,3 @@ const outerRealmFunctionConstructor = Node.constructor;
 window.require = new outerRealmFunctionConstructor("return require")();
 
 window.MessageChannel = require('worker_threads').MessageChannel;
-
-window.scrollTo = function () { }

--- a/downstream-tests/js-ce/src/test/scala/downstream/CatsEffectBundleTests.scala
+++ b/downstream-tests/js-ce/src/test/scala/downstream/CatsEffectBundleTests.scala
@@ -3,18 +3,21 @@ package downstream
 import japgolly.microlibs.testutil.TestUtil._
 import japgolly.scalajs.react.test.ReactTestUtils2
 import utest._
+import cats.effect.testing.utest.EffectTestSuite
+import cats.effect.IO
 
-object CatsEffectBundleTests extends TestSuite {
+object CatsEffectBundleTests extends EffectTestSuite[IO] {
 
   override def tests = Tests {
     Globals.clear()
 
     "catnip" - {
-      ReactTestUtils2.withRenderedSync(Catnip.Component("omg")) { m =>
+      ReactTestUtils2.withRendered_(Catnip.Component("omg")) { m =>
         assertEq(Globals.catnipMounts, List("omg"))
         m.outerHTML.assert("<div>Hello omg</div>")
-      }
-      assertEq(Globals.catnipMounts, List("omg"))
+      }.map(_ =>
+        assertEq(Globals.catnipMounts, List("omg"))
+      )
     }
 
   }

--- a/downstream-tests/js-ce/src/test/scala/downstream/CatsEffectBundleTests.scala
+++ b/downstream-tests/js-ce/src/test/scala/downstream/CatsEffectBundleTests.scala
@@ -10,7 +10,7 @@ object CatsEffectBundleTests extends TestSuite {
     Globals.clear()
 
     "catnip" - {
-      ReactTestUtils2.withRendered(Catnip.Component("omg")) { m =>
+      ReactTestUtils2.withRenderedSync(Catnip.Component("omg")) { m =>
         assertEq(Globals.catnipMounts, List("omg"))
         m.outerHTML.assert("<div>Hello omg</div>")
       }

--- a/downstream-tests/js/src/test/resources/polyfill.js
+++ b/downstream-tests/js/src/test/resources/polyfill.js
@@ -2,5 +2,3 @@ const outerRealmFunctionConstructor = Node.constructor;
 window.require = new outerRealmFunctionConstructor("return require")();
 
 window.MessageChannel = require('worker_threads').MessageChannel;
-
-window.scrollTo = function () { }

--- a/downstream-tests/js/src/test/scala/downstream/AsyncTestSuite.scala
+++ b/downstream-tests/js/src/test/scala/downstream/AsyncTestSuite.scala
@@ -1,0 +1,16 @@
+package japgolly.scalajs.react
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.reflect.ClassTag
+import utest.TestSuite
+
+abstract class AsyncTestSuite extends TestSuite {
+  private val Tag = implicitly[ClassTag[AsyncCallback[Any]]]
+
+  override def utestWrap(path: Seq[String], runBody: => Future[Any])(implicit ec: ExecutionContext): Future[Any] = {
+    runBody flatMap {
+      case Tag(ac) => ac.unsafeToFuture()
+      case other => super.utestWrap(path, Future.successful(other))
+    }
+  }
+}

--- a/downstream-tests/js/src/test/scala/downstream/MimaTests.scala
+++ b/downstream-tests/js/src/test/scala/downstream/MimaTests.scala
@@ -1,20 +1,22 @@
-package downstream
+// package downstream
 
-import japgolly.microlibs.testutil.TestUtil._
-import utest._
+// TODO: Reimplement when we release 3.0.0
 
-object MimaTests extends TestSuite {
+// import japgolly.microlibs.testutil.TestUtil._
+// import utest._
 
-  override def tests = Tests {
+// object MimaTests extends TestSuite {
 
-    // "2_0_0" - {
-    //   import mima200._
+//   override def tests = Tests {
 
-    //   "HookUseRef" - HookUseRef.test { ref =>
-    //     val a = ref.value
-    //     val b = ref.map(_ + 1).unsafeGet()
-    //     assertEq(b, a + 1)
-    //   }
-    // }
-  }
-}
+//     "2_0_0" - {
+//       import mima200._
+
+//       "HookUseRef" - HookUseRef.test { ref =>
+//         val a = ref.value
+//         val b = ref.map(_ + 1).unsafeGet()
+//         assertEq(b, a + 1)
+//       }
+//     }
+//   }
+// }

--- a/downstream-tests/js/src/test/scala/downstream/RuntimeTests.scala
+++ b/downstream-tests/js/src/test/scala/downstream/RuntimeTests.scala
@@ -64,11 +64,11 @@ object RuntimeTests extends TestSuite {
       val (promise, completePromise) = JsUtil.newPromise[Unit]()
       val io = IO(completePromise(Try(()))())
 
-      ReactTestUtils2.withRendered(Carrot.Props("1", io).render) { m =>
+      ReactTestUtils2.withRenderedSync(Carrot.Props("1", io).render) { m =>
         m.root.render(Carrot.Props("1").render)
         m.root.render(Carrot.Props("2").render)
       }
-      ReactTestUtils2.withRendered(Pumpkin.Component("1")) { m =>
+      ReactTestUtils2.withRenderedSync(Pumpkin.Component("1")) { m =>
         m.root.render(Pumpkin.Component("1"))
         m.root.render(Pumpkin.Component("2"))
       }
@@ -90,13 +90,13 @@ object RuntimeTests extends TestSuite {
 
       "react" - {
         val c = ScalaFnComponent[Int](i => <.p(<.td(s"i = $i")))
-        val t = Try(ReactTestUtils2.withRendered(c(123))(_ => ()))
+        val t = Try(ReactTestUtils2.withRenderedSync(c(123))(_ => ()))
         assertEq(t.isFailure, testWarningsReact.contains("react"))
       }
 
       "unlreated" - {
         val c = ScalaFnComponent[Int](i => <.p(s"i = $i"))
-        val t = Try(ReactTestUtils2.withRendered(c(123)) { _ =>
+        val t = Try(ReactTestUtils2.withRenderedSync(c(123)) { _ =>
           console.info(".")
           console.log(".")
           console.warn(".")

--- a/downstream-tests/js/src/test/scala/downstream/RuntimeTests.scala
+++ b/downstream-tests/js/src/test/scala/downstream/RuntimeTests.scala
@@ -12,8 +12,9 @@ import scala.scalajs.js
 import scala.scalajs.LinkingInfo.developmentMode
 import scala.util.Try
 import utest._
+import japgolly.scalajs.react.AsyncTestSuite
 
-object RuntimeTests extends TestSuite {
+object RuntimeTests extends AsyncTestSuite {
 
   val compNameAuto      = CompileTimeInfo.sysProp("japgolly.scalajs.react.component.names.implicit")
   val compNameAll       = CompileTimeInfo.sysProp("japgolly.scalajs.react.component.names.all")
@@ -64,45 +65,51 @@ object RuntimeTests extends TestSuite {
       val (promise, completePromise) = JsUtil.newPromise[Unit]()
       val io = IO(completePromise(Try(()))())
 
-      ReactTestUtils2.withRenderedSync(Carrot.Props("1", io).render) { m =>
-        m.root.render(Carrot.Props("1").render)
-        m.root.render(Carrot.Props("2").render)
-      }
-      ReactTestUtils2.withRenderedSync(Pumpkin.Component("1")) { m =>
-        m.root.render(Pumpkin.Component("1"))
-        m.root.render(Pumpkin.Component("2"))
-      }
-
-      assertEq(Globals.carrotMountsA, 1)
-      assertEq(Globals.carrotMountsB, 1)
-      assertEq(Globals.carrotRenders, expectedCarrots)
-      assertEq(Globals.pumpkinRenders, expectedPumpkins)
-
-      AsyncCallback
-        .fromJsPromise(promise)
-        .map(_ => s"carrots: ${Globals.carrotRenders}/3, pumpkins: ${Globals.pumpkinRenders}/3, reusabilityLog: ${Globals.reusabilityLog.length}")
-        .timeoutMs(3000)
-        .map(_.get)
-        .unsafeToFuture()
+      for {
+        _ <- ReactTestUtils2.withRendered(Carrot.Props("1", io).render) { m =>
+          for {
+            _ <- m.root.render(Carrot.Props("1").render)
+            _ <- m.root.render(Carrot.Props("2").render)
+          } yield ()
+        }
+        _ <- ReactTestUtils2.withRendered(Pumpkin.Component("1")) { m =>
+          for {
+            _ <- m.root.render(Pumpkin.Component("1"))
+            _ <- m.root.render(Pumpkin.Component("2"))
+          } yield ()
+        }
+        _ = assertEq(Globals.carrotMountsA, 1)
+        _ = assertEq(Globals.carrotMountsB, 1)
+        _ = assertEq(Globals.carrotRenders, expectedCarrots)
+        _ = assertEq(Globals.pumpkinRenders, expectedPumpkins)
+        _ <-
+          AsyncCallback
+            .fromJsPromise(promise)
+            .map(_ => s"carrots: ${Globals.carrotRenders}/3, pumpkins: ${Globals.pumpkinRenders}/3, reusabilityLog: ${Globals.reusabilityLog.length}")
+            .timeoutMs(3000)
+            .map(_.get)
+      } yield ()
     }
 
     "testWarnings" - {
 
       "react" - {
         val c = ScalaFnComponent[Int](i => <.p(<.td(s"i = $i")))
-        val t = Try(ReactTestUtils2.withRenderedSync(c(123))(_ => ()))
-        assertEq(t.isFailure, testWarningsReact.contains("react"))
+        ReactTestUtils2.withRendered_(c(123))(_ => ()).attemptTry.map { t =>
+          assertEq(t.isFailure, testWarningsReact.contains("react"))
+        }
       }
 
       "unlreated" - {
         val c = ScalaFnComponent[Int](i => <.p(s"i = $i"))
-        val t = Try(ReactTestUtils2.withRenderedSync(c(123)) { _ =>
+        ReactTestUtils2.withRendered_(c(123)) { _ =>
           console.info(".")
           console.log(".")
           console.warn(".")
           console.error(".")
-        })
-        assertEq(t.isFailure, false)
+        }.attemptTry.map { t =>
+          assertEq(t.isFailure, false)
+        }
       }
     }
   }

--- a/downstream-tests/package.json
+++ b/downstream-tests/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "jsdom": "^25.0.1"
+  }
+}

--- a/downstream-tests/scalafix.sbt
+++ b/downstream-tests/scalafix.sbt
@@ -12,8 +12,6 @@ ThisBuild / semanticdbEnabled := true
 
 ThisBuild / semanticdbVersion := "4.12.0"
 
-ThisBuild / scalafixScalaBinaryVersion := "2.13"
-
 ThisBuild / scalafixDependencies += {
   val ver = version.value.stripSuffix("-SNAPSHOT") + "-SNAPSHOT"
   "com.github.japgolly.scalajs-react" %% "scalafix" % ver

--- a/library/coreGeneric/src/main/scala/japgolly/scalajs/react/CtorType.scala
+++ b/library/coreGeneric/src/main/scala/japgolly/scalajs/react/CtorType.scala
@@ -246,7 +246,7 @@ object CtorType {
       new Summoner[P, C] {
         override type CT[-p, +u] = T[p, u]
         override val summon = f
-        override implicit val pf = p
+        override implicit val pf: Profunctor[T] = p
       }
 
     implicit def summonN[P <: js.Object](implicit s: Singleton[P]): Summoner.Aux[P, ChildrenArg.None, Nullary] =

--- a/library/coreGeneric/src/main/scala/japgolly/scalajs/react/SetStateFns.scala
+++ b/library/coreGeneric/src/main/scala/japgolly/scalajs/react/SetStateFns.scala
@@ -11,8 +11,8 @@ final class SetStateFn[F[_], A[_], S](underlyingFn: (Option[S], F[Unit]) => F[Un
   override type WithEffect     [G[_]] = SetStateFn[G, A, S]
   override type WithAsyncEffect[G[_]] = SetStateFn[F, G, S]
 
-  override protected implicit def F = FF
-  override protected implicit def A = AA
+  override protected implicit def F: UnsafeSync[F] = FF
+  override protected implicit def A: Async[A] = AA
 
   override def withEffect[G[_]](implicit G: UnsafeSync[G]) =
     G.subst[F, WithEffect](this)(new SetStateFn(G.transSyncFn2C(underlyingFn)(F))(G, A))(F)
@@ -51,8 +51,8 @@ final class ModStateFn[F[_], A[_], S](underlyingFn: (S => Option[S], F[Unit]) =>
   override type WithEffect     [G[_]] = ModStateFn[G, A, S]
   override type WithAsyncEffect[G[_]] = ModStateFn[F, G, S]
 
-  override protected implicit def F = FF
-  override protected implicit def A = AA
+  override protected implicit def F: UnsafeSync[F] = FF
+  override protected implicit def A: Async[A] = AA
 
   override def withEffect[G[_]](implicit G: UnsafeSync[G]) =
     G.subst[F, WithEffect](this)(new ModStateFn(G.transSyncFn2C(underlyingFn)(F))(G, A))(F)
@@ -94,8 +94,8 @@ final class ModStateWithPropsFn[F[_], A[_], P, S](underlyingFn: ((S, P) => Optio
   override type WithEffect     [G[_]] = ModStateWithPropsFn[G, A, P, S]
   override type WithAsyncEffect[G[_]] = ModStateWithPropsFn[F, G, P, S]
 
-  override protected implicit def F = FF
-  override protected implicit def A = AA
+  override protected implicit def F: UnsafeSync[F] = FF
+  override protected implicit def A: Async[A] = AA
 
   override def withEffect[G[_]](implicit G: UnsafeSync[G]) =
     G.subst[F, WithEffect](this)(new ModStateWithPropsFn(G.transSyncFn2C(underlyingFn)(F))(G, A))(F)

--- a/library/coreGeneric/src/main/scala/japgolly/scalajs/react/StateAccess.scala
+++ b/library/coreGeneric/src/main/scala/japgolly/scalajs/react/StateAccess.scala
@@ -153,8 +153,8 @@ object StateAccess {
       override type WithAsyncEffect[G[_]] = StateAccess[F, G, S]
       override type WithMappedState[T]    = StateAccess[F, A, T]
 
-      override protected implicit def F = FF
-      override protected implicit def A = AA
+      override protected implicit def F: UnsafeSync[F] = FF
+      override protected implicit def A: Async[A] = AA
 
       override def state = stateFn
 
@@ -197,8 +197,8 @@ object StateAccess {
       override type WithAsyncEffect[G[_]] = StateAccess[F, G, S]
       override type WithMappedState[T]    = StateAccess[F, A, T]
 
-      override protected implicit def F = FF
-      override protected implicit def A = AA
+      override protected implicit def F: UnsafeSync[F] = FF
+      override protected implicit def A: Async[A] = AA
 
       override def state = stateFn
 

--- a/library/coreGeneric/src/main/scala/japgolly/scalajs/react/component/Js.scala
+++ b/library/coreGeneric/src/main/scala/japgolly/scalajs/react/component/Js.scala
@@ -132,14 +132,14 @@ object Js extends JsBaseComponentTemplate[facade.React.ComponentClassP] {
     new Template.MountedWithRoot[Id, DefaultA, P, S]()(UnsafeSync.id, DefaultA)
         with MountedRoot[Id, DefaultA, P, S, R] {
 
-      override implicit def F    = UnsafeSync.id
-      override implicit def A    = DefaultA
-      override def root          = this
-      override val raw           = r
-      override def props         = raw.props
-      override def propsChildren = PropsChildren.fromRawProps(raw.props)
-      override def state         = raw.state
-      override def getDOMNode    = ComponentDom.findDOMNode(raw)
+      override implicit def F: UnsafeSync[Id]       = UnsafeSync.id
+      override implicit def A: Async[Async.Untyped] = DefaultA
+      override def root                             = this
+      override val raw                              = r
+      override def props                            = raw.props
+      override def propsChildren                    = PropsChildren.fromRawProps(raw.props)
+      override def state                            = raw.state
+      override def getDOMNode                       = ComponentDom.findDOMNode(raw)
 
       override def setState[G[_]](state: S, callback: => G[Unit])(implicit G: Dispatch[G]): Unit =
         raw.setState(state, G.dispatchFn(callback))

--- a/library/facadeMain/src/main/scala/japgolly/scalajs/react/facade/React.scala
+++ b/library/facadeMain/src/main/scala/japgolly/scalajs/react/facade/React.scala
@@ -180,7 +180,7 @@ object React extends React {
 }
 
 @js.native
-trait React extends Hooks with Act {
+trait React extends Hooks with Testing {
   import React._
 
   final def createContext[A](defaultValue: A): React.Context[A] = js.native

--- a/library/facadeMain/src/main/scala/japgolly/scalajs/react/facade/ReactDOM.scala
+++ b/library/facadeMain/src/main/scala/japgolly/scalajs/react/facade/ReactDOM.scala
@@ -1,7 +1,6 @@
 package japgolly.scalajs.react.facade
 
 import org.scalajs.dom
-import scala.annotation.nowarn
 import scala.scalajs.js
 import scala.scalajs.js.annotation._
 import scala.scalajs.js.|
@@ -11,7 +10,6 @@ import scala.scalajs.js.|
 object ReactDOM extends ReactDOM
 
 @js.native
-@nowarn("cat=unused")
 trait ReactDOM extends js.Object {
 
   final type Container          = dom.Element | dom.Document | dom.DocumentFragment

--- a/library/facadeMain/src/main/scala/japgolly/scalajs/react/facade/ReactDOMClient.scala
+++ b/library/facadeMain/src/main/scala/japgolly/scalajs/react/facade/ReactDOMClient.scala
@@ -1,7 +1,6 @@
 package japgolly.scalajs.react.facade
 
 import org.scalajs.dom
-import scala.annotation.nowarn
 import scala.scalajs.js
 import scala.scalajs.js.annotation._
 import scala.scalajs.js.|
@@ -11,7 +10,6 @@ import scala.scalajs.js.|
 object ReactDOMClient extends ReactDOMClient
 
 @js.native
-@nowarn("cat=unused")
 trait ReactDOMClient extends js.Object {
   final type HydrationContainer = dom.Element | dom.Document
   final type RootContainer      = dom.Element | dom.DocumentFragment
@@ -24,7 +22,6 @@ trait ReactDOMClient extends js.Object {
 }
 
 @js.native
-@nowarn("cat=unused")
 trait RootType extends js.Object {
   def render(element: React.Node): Unit = js.native
   def unmount(): Unit = js.native

--- a/library/facadeMain/src/main/scala/japgolly/scalajs/react/facade/ReactDOMServer.scala
+++ b/library/facadeMain/src/main/scala/japgolly/scalajs/react/facade/ReactDOMServer.scala
@@ -1,6 +1,5 @@
 package japgolly.scalajs.react.facade
 
-import scala.annotation.nowarn
 import scala.scalajs.js
 import scala.scalajs.js.annotation._
 
@@ -9,7 +8,6 @@ import scala.scalajs.js.annotation._
 object ReactDOMServer extends ReactDOMServer
 
 @js.native
-@nowarn("cat=unused")
 trait ReactDOMServer extends js.Object {
 
   val version: String = js.native

--- a/library/facadeMain/src/main/scala/japgolly/scalajs/react/facade/Testing.scala
+++ b/library/facadeMain/src/main/scala/japgolly/scalajs/react/facade/Testing.scala
@@ -1,13 +1,13 @@
 package japgolly.scalajs.react.facade
 
-import scalajs.js
-import scalajs.js.annotation.JSName
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSName
 
 /** 
   * @since React 18.3.0 / scalajs-react 3.0.0
   */
 @js.native
-trait Act extends js.Object {
+trait Testing extends js.Object {
   /** When writing UI tests, tasks like rendering, user events, or data fetching can be considered as "units" of
     * interaction with a user interface. React provides a helper called act() that makes sure all updates related to
     * these "units" have been processed and applied to the DOM before you make any assertions:

--- a/library/facadeMain/src/main/scala/japgolly/scalajs/react/facade/Testing.scala
+++ b/library/facadeMain/src/main/scala/japgolly/scalajs/react/facade/Testing.scala
@@ -20,8 +20,15 @@ trait Testing extends js.Object {
     * }}}
     *
     * This helps make your tests run closer to what real users would experience when using your application.
+    *
+    * Note: We recommend using the async version of `act`. Although the sync version works in many cases, it doesn’t
+    * work in all cases and due to the way React schedules updates internally, it’s difficult to predict when you 
+    * can use the sync version.
+    *
+    * We will deprecate and remove the sync version in the future.
     */
-  final def act(body: js.Function0[Any]): js.Thenable[Unit] = js.native
+  @JSName("act")
+  final def actSync(body: js.Function0[Any]): js.Thenable[Unit] = js.native
 
 /** When writing UI tests, tasks like rendering, user events, or data fetching can be considered as "units" of
   * interaction with a user interface. React provides a helper called act() that makes sure all updates related to
@@ -36,6 +43,5 @@ trait Testing extends js.Object {
   *
   * This helps make your tests run closer to what real users would experience when using your application.
   */
-  @JSName("act")
-  final def actAsync[A](body: js.Function0[js.Thenable[A]]): js.Thenable[A] = js.native
+  final def act[A](body: js.Function0[js.Thenable[A]]): js.Thenable[A] = js.native
 }

--- a/library/facadeMain/src/main/scala/japgolly/scalajs/react/facade/events.scala
+++ b/library/facadeMain/src/main/scala/japgolly/scalajs/react/facade/events.scala
@@ -1,7 +1,6 @@
 package japgolly.scalajs.react.facade
 
 import org.scalajs.dom
-import scala.annotation.nowarn
 import scala.scalajs.js
 import scala.scalajs.js.annotation.JSName
 
@@ -125,7 +124,6 @@ trait SyntheticFormEvent[+DOMEventTarget <: dom.Node] extends SyntheticUIEvent[D
 
 /** https://github.com/facebook/react/blob/master/packages/react-dom/src/events/SyntheticKeyboardEvent.js */
 @js.native
-@nowarn("cat=unused")
 trait SyntheticKeyboardEvent[+DOMEventTarget <: dom.Node] extends SyntheticUIEvent[DOMEventTarget] {
   override val nativeEvent: dom.KeyboardEvent = js.native
   val location : Double  = js.native
@@ -170,7 +168,6 @@ trait SyntheticKeyboardEvent[+DOMEventTarget <: dom.Node] extends SyntheticUIEve
 
 /** https://github.com/facebook/react/blob/master/packages/react-dom/src/events/SyntheticMouseEvent.js */
 @js.native
-@nowarn("cat=unused")
 trait SyntheticMouseEvent[+DOMEventTarget <: dom.Node] extends SyntheticUIEvent[DOMEventTarget] {
   override val nativeEvent: dom.MouseEvent = js.native
   val screenX: Double = js.native
@@ -232,7 +229,6 @@ trait SyntheticPointerEvent[+DOMEventTarget <: dom.Node] extends SyntheticMouseE
 
 /** https://github.com/facebook/react/blob/master/packages/react-dom/src/events/SyntheticTouchEvent.js */
 @js.native
-@nowarn("cat=unused")
 trait SyntheticTouchEvent[+DOMEventTarget <: dom.Node] extends SyntheticUIEvent[DOMEventTarget] {
   override val nativeEvent: dom.TouchEvent = js.native
   val altKey        : Boolean       = js.native

--- a/library/facadeTest/src/main/scala/japgolly/scalajs/react/test/facade/ReactTestUtils.scala
+++ b/library/facadeTest/src/main/scala/japgolly/scalajs/react/test/facade/ReactTestUtils.scala
@@ -1,7 +1,6 @@
 package japgolly.scalajs.react.test.facade
 
 import japgolly.scalajs.react.facade._
-import scala.annotation.nowarn
 import scala.scalajs.js
 import scala.scalajs.js.annotation._
 import scala.scalajs.js.|

--- a/library/project/Build.scala
+++ b/library/project/Build.scala
@@ -214,6 +214,7 @@ object ScalaJsReact {
     .dependsOn(coreBundleCallback) // Low priority
     .configure(commonSettings, preventPublication, utestSettings, addReactJsDependencies(Test))
     .settings(
+      // Test / parallelExecution := false,
       Test / scalacOptions --= Seq(
         "-deprecation",
         "-Xlint:adapted-args"

--- a/library/project/Build.scala
+++ b/library/project/Build.scala
@@ -214,7 +214,6 @@ object ScalaJsReact {
     .dependsOn(coreBundleCallback) // Low priority
     .configure(commonSettings, preventPublication, utestSettings, addReactJsDependencies(Test))
     .settings(
-      // Test / parallelExecution := false,
       Test / scalacOptions --= Seq(
         "-deprecation",
         "-Xlint:adapted-args"

--- a/library/project/Dependencies.scala
+++ b/library/project/Dependencies.scala
@@ -33,7 +33,7 @@ object Dependencies {
     val scalaTest             = "3.2.11"
     val sizzleJs              = "2.3.0"
     val univEq                = "2.0.0"
-    val utest                 = "0.7.11"
+    val utest                 = "0.8.5"
   }
 
   object Dep {

--- a/library/project/Lib.scala
+++ b/library/project/Lib.scala
@@ -116,7 +116,7 @@ object Lib {
   def utestSettings(scope: Configuration): PE =
     _.configure(InBrowserTesting.js)
       .settings(
-        jsEnv                := new JSDOMNodeJSEnv,
+        jsEnv                := new JSDOMNodeJSEnv(JSDOMNodeJSEnv.Config().withArgs("--experimental-worker" :: Nil)),
         Test / scalacOptions += "-language:reflectiveCalls",
         libraryDependencies  += Dep.utest.value % scope,
         libraryDependencies  += Dep.microlibsTestUtil.value % scope,

--- a/library/project/plugins.sbt
+++ b/library/project/plugins.sbt
@@ -5,4 +5,4 @@ libraryDependencies ++= Seq(
 addSbtPlugin("ch.epfl.scala"  % "sbt-scalafix"       % "0.12.1")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release"     % "1.9.0")
 addSbtPlugin("org.scala-js"   % "sbt-jsdependencies" % "1.0.2")
-addSbtPlugin("org.scala-js"   % "sbt-scalajs"        % "1.16.0")
+addSbtPlugin("org.scala-js"   % "sbt-scalajs"        % "1.17.0")

--- a/library/testUtil/src/main/scala/japgolly/scalajs/react/test/MockRouterCtlF.scala
+++ b/library/testUtil/src/main/scala/japgolly/scalajs/react/test/MockRouterCtlF.scala
@@ -16,7 +16,7 @@ class MockRouterCtlF[F[_], P](override val baseUrl: BaseUrl, pageToPath: P => Pa
 
   override val byPath: RouterCtlF[F, Path] =
     new RouterCtlF[F, Path] {
-    override protected implicit def F           = self.F
+    override protected implicit def F: Sync[F]  = self.F
       override def byPath                       = this
       override def baseUrl                      = self.baseUrl
       override def refresh                      = self.refresh

--- a/library/testUtil/src/main/scala/japgolly/scalajs/react/test/ReactTestUtils.scala
+++ b/library/testUtil/src/main/scala/japgolly/scalajs/react/test/ReactTestUtils.scala
@@ -279,7 +279,7 @@ trait ReactTestUtils extends japgolly.scalajs.react.test.internal.ReactTestUtilE
     new WithRenderedDsl[M, Element] {
       override def apply[A](f: (M, Element) => A): A =
         withNewBodyElement { parent =>
-          aroundReact {
+          aroundReact.sync {
             val c = act(RawReactDOM.render(u.raw, parent))
             try
               f(u.mountRawOrNull(c), parent)
@@ -357,7 +357,7 @@ trait ReactTestUtils extends japgolly.scalajs.react.test.internal.ReactTestUtilE
   def withRenderedIntoDocument[M](u: Unmounted[M]): WithRenderedDsl[M, Element] =
     new WithRenderedDsl[M, Element] {
       override def apply[A](f: (M, Element) => A): A =
-        aroundReact {
+        aroundReact.sync {
           val c = act(raw.renderIntoDocument(u.raw))
           try {
             val p = parentElement(c)

--- a/library/testUtil/src/main/scala/japgolly/scalajs/react/test/ReactTestUtils2.scala
+++ b/library/testUtil/src/main/scala/japgolly/scalajs/react/test/ReactTestUtils2.scala
@@ -113,7 +113,7 @@ trait ReactTestUtils2 extends japgolly.scalajs.react.test.internal.ReactTestUtil
   val withElementSync: WithDsl[Element, ImplicitUnit] =
     WithDsl(newElement())(removeElement)
 
-  def withElement[F[_]: Effect]: Resource[F, Element] =
+  def withElement[F[_]: Async]: Resource[F, Element] =
     Resource.make(Effect[F].delay(newElement()), e => Effect[F].delay(removeElement(e)))
 
   val withReactRootSync: WithDsl[TestReactRoot, ImplicitUnit] =

--- a/library/testUtil/src/main/scala/japgolly/scalajs/react/test/Simulate.scala
+++ b/library/testUtil/src/main/scala/japgolly/scalajs/react/test/Simulate.scala
@@ -25,7 +25,7 @@ object Simulate {
 
   private def wrap(f: => Unit): Unit =
     if (React.majorVersion >= 18 && ReactTestUtils2.IsReactActEnvironment())
-      ReactTestUtils2.act(f)
+      ReactTestUtils2.actSync(f)
     else
       f
 

--- a/library/testUtil/src/main/scala/japgolly/scalajs/react/test/TestContainer.scala
+++ b/library/testUtil/src/main/scala/japgolly/scalajs/react/test/TestContainer.scala
@@ -7,7 +7,7 @@ object TestContainer {
   def apply(c: mainFacade.ReactDOM.Container): TestContainer =
     new TestContainer {
       override type Self = TestDom
-      override protected def Self(n2: dom.Node) = TestDom(n2)
+      override protected def Self(n2: Option[dom.Node]) = TestDom(n2)
       override def container = c
       override def toString = s"TestContainer($c)"
     }
@@ -25,8 +25,8 @@ trait TestContainer extends TestDom {
 
   def container: mainFacade.ReactDOM.Container
 
-  final def node =
-    fold(identity, identity, identity)
+  final def node: Option[dom.Node] =
+    Some(fold(identity, identity, identity))
 
   def fold[A](onElement         : dom.Element          => A,
               onDocument        : dom.Document         => A,
@@ -38,7 +38,7 @@ trait TestContainer extends TestDom {
     }
 
   def isEmpty(): Boolean =
-    node.childNodes.length == 0
+    node.forall(_.childNodes.length == 0)
 
   @inline final def nonEmpty(): Boolean =
     !isEmpty()

--- a/library/testUtil/src/main/scala/japgolly/scalajs/react/test/TestDomWithRoot.scala
+++ b/library/testUtil/src/main/scala/japgolly/scalajs/react/test/TestDomWithRoot.scala
@@ -1,5 +1,6 @@
 package japgolly.scalajs.react.test
 
+import japgolly.scalajs.react.util.Effect.Async
 import org.scalajs.dom
 
 object TestDomWithRoot {
@@ -21,6 +22,12 @@ trait TestDomWithRoot extends TestDom {
 
   @inline def act[A](body: => A): A = 
     root.act(body)
+
+  @inline def actAsync[F[_], A](body: F[A])(implicit F: Async[F]): F[A] =
+    root.actAsync(body)
+
+  @inline def actAsync_[F[_], A](body: => A)(implicit F: Async[F]): F[A] =
+    root.actAsync_(body)
 
   @inline def unmount(): Unit =
     root.unmount()

--- a/library/testUtil/src/main/scala/japgolly/scalajs/react/test/TestDomWithRoot.scala
+++ b/library/testUtil/src/main/scala/japgolly/scalajs/react/test/TestDomWithRoot.scala
@@ -41,4 +41,10 @@ trait TestDomWithRoot extends TestDom {
 
   def withNode_[F[_]: Effect](f: dom.Node => Unit): F[Unit] = 
     withNode(n => Effect[F].delay(f(n)))
+
+  def actOnNode[F[_]: Async](f: dom.Node => F[Unit]): F[Unit] = 
+    withNode(n => act(f(n)))
+
+  def actOnNode_[F[_]: Async](f: dom.Node => Unit): F[Unit] = 
+    withNode(n => act_(f(n)))
 }

--- a/library/testUtil/src/main/scala/japgolly/scalajs/react/test/TestDomWithRoot.scala
+++ b/library/testUtil/src/main/scala/japgolly/scalajs/react/test/TestDomWithRoot.scala
@@ -1,5 +1,6 @@
 package japgolly.scalajs.react.test
 
+import japgolly.scalajs.react.util.Effect
 import japgolly.scalajs.react.util.Effect.Async
 import org.scalajs.dom
 
@@ -34,4 +35,10 @@ trait TestDomWithRoot extends TestDom {
 
   @inline def unmount[F[_]: Async](): F[Unit] =
     root.unmount()
+
+  def withNode[F[_]: Effect](f: dom.Node => F[Unit]): F[Unit] = 
+    node.map(f).getOrElse(Effect[F].throwException(new RuntimeException("Node not rendered")))
+
+  def withNode_[F[_]: Effect](f: dom.Node => Unit): F[Unit] = 
+    withNode(n => Effect[F].delay(f(n)))
 }

--- a/library/testUtil/src/main/scala/japgolly/scalajs/react/test/TestDomWithRoot.scala
+++ b/library/testUtil/src/main/scala/japgolly/scalajs/react/test/TestDomWithRoot.scala
@@ -19,6 +19,9 @@ trait TestDomWithRoot extends TestDom {
   override type Self <: TestDomWithRoot
   val root: TestReactRoot
 
+  @inline def act[A](body: => A): A = 
+    root.act(body)
+
   @inline def unmount(): Unit =
     root.unmount()
 }

--- a/library/testUtil/src/main/scala/japgolly/scalajs/react/test/TestDomWithRoot.scala
+++ b/library/testUtil/src/main/scala/japgolly/scalajs/react/test/TestDomWithRoot.scala
@@ -20,15 +20,18 @@ trait TestDomWithRoot extends TestDom {
   override type Self <: TestDomWithRoot
   val root: TestReactRoot
 
-  @inline def act[A](body: => A): A = 
+  @inline def actSync[A](body: => A): A = 
+    root.actSync(body)
+
+  @inline def act[F[_]: Async, A](body: F[A]): F[A] =
     root.act(body)
 
-  @inline def actAsync[F[_], A](body: F[A])(implicit F: Async[F]): F[A] =
-    root.actAsync(body)
+  @inline def act_[F[_]: Async, A](body: => A): F[A] =
+    root.act_(body)
 
-  @inline def actAsync_[F[_], A](body: => A)(implicit F: Async[F]): F[A] =
-    root.actAsync_(body)
+  @inline def unmountSync(): Unit =
+    root.unmountSync()
 
-  @inline def unmount(): Unit =
+  @inline def unmount[F[_]: Async](): F[Unit] =
     root.unmount()
 }

--- a/library/testUtil/src/main/scala/japgolly/scalajs/react/test/TestDomWithRoot.scala
+++ b/library/testUtil/src/main/scala/japgolly/scalajs/react/test/TestDomWithRoot.scala
@@ -3,10 +3,10 @@ package japgolly.scalajs.react.test
 import org.scalajs.dom
 
 object TestDomWithRoot {
-  def apply(r: TestReactRoot, n: dom.Node): TestDomWithRoot =
+  def apply(r: TestReactRoot, n: Option[dom.Node]): TestDomWithRoot =
     new TestDomWithRoot {
       override type Self = TestDomWithRoot
-      override protected def Self(n2: dom.Node) = TestDomWithRoot(root, n2)
+      override protected def Self(n2: Option[dom.Node]) = TestDomWithRoot(root, n2)
       override val root = r
       override def node = n
       override def toString = s"TestDomWithRoot($node)"

--- a/library/testUtil/src/main/scala/japgolly/scalajs/react/test/TestReactRoot.scala
+++ b/library/testUtil/src/main/scala/japgolly/scalajs/react/test/TestReactRoot.scala
@@ -1,6 +1,7 @@
 package japgolly.scalajs.react.test
 
 import japgolly.scalajs.react.{facade => mainFacade, _}
+import japgolly.scalajs.react.util.Effect.Async
 import org.scalajs.dom
 
 object TestReactRoot {
@@ -40,6 +41,12 @@ trait TestReactRoot extends TestContainer {
 
   def act[A](body: => A): A = 
     ReactTestUtils2.act(body)
+
+  def actAsync[F[_], A](body: F[A])(implicit F: Async[F]): F[A] =
+    ReactTestUtils2.actAsync(body)
+
+  @inline def actAsync_[F[_], A](body: => A)(implicit F: Async[F]): F[A] =
+    ReactTestUtils2.actAsync_(body)
 
   def render[A](unmounted: A)(implicit r: Renderable[A]): Unit =
     act(root.render(unmounted))

--- a/library/testUtil/src/main/scala/japgolly/scalajs/react/test/TestReactRoot.scala
+++ b/library/testUtil/src/main/scala/japgolly/scalajs/react/test/TestReactRoot.scala
@@ -13,7 +13,7 @@ object TestReactRoot {
     @inline def c = container
     new TestReactRoot {
       override type Self = TestDomWithRoot
-      override protected def Self(n2: dom.Node) = TestDomWithRoot(this, n2)
+      override protected def Self(n2: Option[dom.Node]) = TestDomWithRoot(this, n2)
       override def root = r
 
       override def container = c
@@ -38,9 +38,12 @@ trait TestReactRoot extends TestContainer {
   @inline def raw =
     root.raw
 
+  def act[A](body: => A): A = 
+    ReactTestUtils2.act(body)
+
   def render[A](unmounted: A)(implicit r: Renderable[A]): Unit =
-    ReactTestUtils2.act(root.render(unmounted))
+    act(root.render(unmounted))
 
   def unmount(): Unit =
-    ReactTestUtils2.act(root.unmount())
+    act(root.unmount())
 }

--- a/library/testUtil/src/main/scala/japgolly/scalajs/react/test/TestReactRoot.scala
+++ b/library/testUtil/src/main/scala/japgolly/scalajs/react/test/TestReactRoot.scala
@@ -1,7 +1,7 @@
 package japgolly.scalajs.react.test
 
-import japgolly.scalajs.react.{facade => mainFacade, _}
 import japgolly.scalajs.react.util.Effect.Async
+import japgolly.scalajs.react.{facade => mainFacade, _}
 import org.scalajs.dom
 
 object TestReactRoot {
@@ -53,4 +53,7 @@ trait TestReactRoot extends TestContainer {
 
   def unmount(): Unit =
     act(root.unmount())
+
+  def unmountAsync[F[_]: Async](): F[Unit] =
+    actAsync_(root.unmount())
 }

--- a/library/testUtil/src/main/scala/japgolly/scalajs/react/test/TestReactRoot.scala
+++ b/library/testUtil/src/main/scala/japgolly/scalajs/react/test/TestReactRoot.scala
@@ -39,21 +39,24 @@ trait TestReactRoot extends TestContainer {
   @inline def raw =
     root.raw
 
-  def act[A](body: => A): A = 
+  def actSync[A](body: => A): A = 
+    ReactTestUtils2.actSync(body)
+
+  def act[F[_]: Async, A](body: F[A]): F[A] =
     ReactTestUtils2.act(body)
 
-  def actAsync[F[_], A](body: F[A])(implicit F: Async[F]): F[A] =
-    ReactTestUtils2.actAsync(body)
+  @inline def act_[F[_]: Async, A](body: => A): F[A] =
+    ReactTestUtils2.act_(body)
 
-  @inline def actAsync_[F[_], A](body: => A)(implicit F: Async[F]): F[A] =
-    ReactTestUtils2.actAsync_(body)
+  def renderSync[A: Renderable](unmounted: A): Unit =
+    actSync(root.render(unmounted))
 
-  def render[A](unmounted: A)(implicit r: Renderable[A]): Unit =
-    act(root.render(unmounted))
+  def render[F[_]: Async, A: Renderable](unmounted: A): F[Unit] =
+    act_(root.render(unmounted))
 
-  def unmount(): Unit =
-    act(root.unmount())
+  def unmountSync(): Unit =
+    actSync(root.unmount())
 
-  def unmountAsync[F[_]: Async](): F[Unit] =
-    actAsync_(root.unmount())
+  def unmount[F[_]: Async](): F[Unit] =
+    act_(root.unmount())
 }

--- a/library/testUtil/src/main/scala/japgolly/scalajs/react/test/internal/HtmlAssertionDsl.scala
+++ b/library/testUtil/src/main/scala/japgolly/scalajs/react/test/internal/HtmlAssertionDsl.scala
@@ -20,11 +20,11 @@ object HtmlAssertionDsl {
     }
 
   def node(name     : String,
-           node     : => dom.Node,
+           node     : => Option[dom.Node],
            onElement: dom.Element => String,
            onNode   : dom.Node => String = _.nodeValue): HtmlAssertionDsl = {
     def read(sanitise: String => String): String =
-      node match {
+      node.fold(""){
         case e: dom.Element => sanitise(onElement(e))
         case n              => onNode(n)
       }

--- a/library/testUtil/src/main/scala/japgolly/scalajs/react/test/internal/Resource.scala
+++ b/library/testUtil/src/main/scala/japgolly/scalajs/react/test/internal/Resource.scala
@@ -1,0 +1,56 @@
+package japgolly.scalajs.react.test.internal
+
+import japgolly.scalajs.react.util.Effect
+
+/** 
+  * Managed resource.
+  *
+  * @since 3.0.0
+  */
+class Resource[F[_]: Effect, A](private val acquire: F[A], private val release: A => F[Unit]) {
+  private val F = implicitly[Effect[F]]
+
+  def use[B](f: A => F[B]): F[B] = 
+    F.flatMap(acquire)(a => F.finallyRun(f(a), release(a)))
+
+  def use_[B](f: A => B): F[B] = 
+    use(a => F.pure(f(a)))
+
+  def flatMap[B](f: A => Resource[F, B]): Resource[F, B] = {
+    var aOpt: Option[A] = None
+    var bReleaseOpt: Option[B => F[Unit]] = None
+
+    Resource.make(
+      F.flatMap(acquire){ a =>
+        aOpt = Some(a)
+        val other: Resource[F, B] = f(a) 
+        bReleaseOpt = Some(other.release)
+        other.acquire
+      },
+      b => 
+        (aOpt, bReleaseOpt) match {
+          case (Some(a), Some(bRelease)) => F.finallyRun(bRelease(b), release(a))
+          case _ => F.throwException(new IllegalStateException("Resource.flatMap: release attempted without acquire being invoked") )
+        }
+    )
+  }
+
+  def map[B](f: A => B): Resource[F, B] =
+    flatMap(a => Resource.pure(f(a)))
+}
+
+object Resource {
+  @inline def make[F[_]: Effect, A](acquire: F[A], release: A => F[Unit]): Resource[F, A] = 
+    new Resource(acquire, release)
+  
+  @inline def make_[F[_]: Effect, A](acquire: => A, release: A => F[Unit]): Resource[F, A] = 
+    make(Effect[F].delay(acquire), release)
+
+  @inline def eval[F[_]: Effect, A](a: F[A]): Resource[F, A] = 
+    Resource.make(a, _ => Effect[F].unit)
+
+  @inline def pure[F[_]: Effect, A](a: A): Resource[F, A] =
+    Resource.eval(Effect[F].pure(a))
+
+  @inline def unit[F[_]: Effect]: Resource[F, Unit] = pure(())
+}

--- a/library/testUtilMacros/src/main/scala/japgolly/scalajs/react/test/internal/ReactTestUtilsConfigTypes.scala
+++ b/library/testUtilMacros/src/main/scala/japgolly/scalajs/react/test/internal/ReactTestUtilsConfigTypes.scala
@@ -1,7 +1,6 @@
 package japgolly.scalajs.react.test.internal
 
-import japgolly.scalajs.react.util.ConsoleHijack
-import japgolly.scalajs.react.util.Effect
+import japgolly.scalajs.react.util.{ConsoleHijack, Effect}
 
 object ReactTestUtilsConfigTypes {
 

--- a/library/tests/src/test/resources/polyfill.js
+++ b/library/tests/src/test/resources/polyfill.js
@@ -1,4 +1,13 @@
-// https://github.com/scala-js/scala-js-env-jsdom-nodejs/issues/44
-// window.MessageChannel = require('worker_threads').MessageChannel;
+const outerRealmFunctionConstructor = Node.constructor;
+// const nodeGlobal = new outerRealmFunctionConstructor("return global")();
+// nodeGlobal.document = document;
+// nodeGlobal.navigator = navigator;
+// nodeGlobal.window = window;
+// nodeGlobal.Event = window.Event;
+// nodeGlobal.CustomEvent = window.CustomEvent;
+// nodeGlobal.IS_REACT_ACT_ENVIRONMENT = true;
+window.require = new outerRealmFunctionConstructor("return require")();
 
-window.scrollTo = function(){}
+window.MessageChannel = require('worker_threads').MessageChannel;
+
+window.scrollTo = function () { }

--- a/library/tests/src/test/scala-2/japgolly/scalajs/react/core/ScalaSpecificHooksTest.scala
+++ b/library/tests/src/test/scala-2/japgolly/scalajs/react/core/ScalaSpecificHooksTest.scala
@@ -33,9 +33,10 @@ object ScalaSpecificHooksTest {
       t.assertText("3:5:9")
       assertEq(counter.value, 10 + (5+3) + (5+3+1))
       counter.value = 0
-      t.clickButton()
-      t.assertText("4:5:9")
-      assertEq(counter.value, 10 + (5+4) + (5+4+1))
+      t.clickButton().map{ _ => 
+        t.assertText("4:5:9")
+        assertEq(counter.value, 10 + (5+4) + (5+4+1))
+      }
     }
   }
 

--- a/library/tests/src/test/scala-3/japgolly/scalajs/react/core/ScalaSpecificHooksTest.scala
+++ b/library/tests/src/test/scala-3/japgolly/scalajs/react/core/ScalaSpecificHooksTest.scala
@@ -33,9 +33,10 @@ object ScalaSpecificHooksTest {
       t.assertText("3:5:9")
       assertEq(counter.value, 10 + (5+3) + (5+3+1))
       counter.value = 0
-      t.clickButton()
-      t.assertText("4:5:9")
-      assertEq(counter.value, 10 + (5+4) + (5+4+1))
+      t.clickButton().map{ _ => 
+        t.assertText("4:5:9")
+        assertEq(counter.value, 10 + (5+4) + (5+4+1))
+      }
     }
   }
 

--- a/library/tests/src/test/scala/japgolly/scalajs/react/AsyncTestSuite.scala
+++ b/library/tests/src/test/scala/japgolly/scalajs/react/AsyncTestSuite.scala
@@ -1,0 +1,16 @@
+package japgolly.scalajs.react
+
+import scala.reflect.ClassTag
+import scala.concurrent.{ExecutionContext, Future}
+import utest.TestSuite
+
+abstract class AsyncTestSuite extends TestSuite {
+  private val Tag = implicitly[ClassTag[AsyncCallback[Any]]]
+
+  override def utestWrap(path: Seq[String], runBody: => Future[Any])(implicit ec: ExecutionContext): Future[Any] = {
+    runBody flatMap {
+      case Tag(ac) => ac.unsafeToFuture()
+      case other => super.utestWrap(path, Future.successful(other))
+    }
+  }
+}

--- a/library/tests/src/test/scala/japgolly/scalajs/react/AsyncTestSuite.scala
+++ b/library/tests/src/test/scala/japgolly/scalajs/react/AsyncTestSuite.scala
@@ -1,7 +1,7 @@
 package japgolly.scalajs.react
 
-import scala.reflect.ClassTag
 import scala.concurrent.{ExecutionContext, Future}
+import scala.reflect.ClassTag
 import utest.TestSuite
 
 abstract class AsyncTestSuite extends TestSuite {

--- a/library/tests/src/test/scala/japgolly/scalajs/react/MiscTest.scala
+++ b/library/tests/src/test/scala/japgolly/scalajs/react/MiscTest.scala
@@ -97,10 +97,8 @@ object MiscTest extends AsyncTestSuite {
           .build
         ReactTestUtils2.withRendered(C()) { d =>
           d.select("span").innerHTML.assert("3")
-          d.withNode( n =>
-            d.act_(Simulate.click(n)).map(_ =>
-              d.select("span").innerHTML.assert("11")
-            )
+          d.actOnNode_(Simulate.click(_)).map(_ =>
+            d.select("span").innerHTML.assert("11")
           )
         }
       }
@@ -115,18 +113,16 @@ object MiscTest extends AsyncTestSuite {
             <.button($.state.toString, ^.onClick --> (add1 >> add7), ^.onDoubleClick --> $.setState(StrInt("oh", 100)))
           }
           .build
-        ReactTestUtils2.withRendered(C()) ( d =>
-          d.withNode{ n => 
-            d.innerHTML.assert("StrInt(yay,3)")
-            for {
-              _ <- d.act_(Simulate.click(n))
-              _  = d.innerHTML.assert("StrInt(yay,11)")
-              _ <- d.act_(Simulate.doubleClick(n))
-              _ <- d.act_(Simulate.click(n))
-            } yield
-              d.innerHTML.assert("StrInt(oh,108)")
-          }
-        )
+        ReactTestUtils2.withRendered(C()) { d =>
+          d.innerHTML.assert("StrInt(yay,3)")
+          for {
+            _ <- d.actOnNode_(Simulate.click(_))
+            _  = d.innerHTML.assert("StrInt(yay,11)")
+            _ <- d.actOnNode_(Simulate.doubleClick(_))
+            _ <- d.actOnNode_(Simulate.click(_))
+          } yield
+            d.innerHTML.assert("StrInt(oh,108)")
+        }
       }
 
       "zoomStateL" - {
@@ -140,16 +136,14 @@ object MiscTest extends AsyncTestSuite {
           }
           .build
         ReactTestUtils2.withRendered(C()) { d =>
-          d.withNode{ n => 
-            d.innerHTML.assert("StrInt(yay,3)")
-            for {
-              _ <- d.act_(Simulate.click(n))
-              _  = d.innerHTML.assert("StrInt(yay,11)")
-              _ <- d.act_(Simulate.doubleClick(n))
-              _ <- d.act_(Simulate.click(n))
-            } yield
-              d.innerHTML.assert("StrInt(oh,108)")
-          }
+          d.innerHTML.assert("StrInt(yay,3)")
+          for {
+            _ <- d.actOnNode_(Simulate.click(_))
+            _  = d.innerHTML.assert("StrInt(yay,11)")
+            _ <- d.actOnNode_(Simulate.doubleClick(_))
+            _ <- d.actOnNode_(Simulate.click(_))
+          } yield
+            d.innerHTML.assert("StrInt(oh,108)")
         }
       }
 
@@ -163,18 +157,16 @@ object MiscTest extends AsyncTestSuite {
             <.button($.state.toString, ^.onClick --> (add1 >> add7), ^.onDoubleClick --> $.setState(StrIntWrap(StrInt("oh", 100))))
           }
           .build
-        ReactTestUtils2.withRendered(C()) ( d =>
-          d.withNode{ n => 
-            d.innerHTML.assert("StrIntWrap(StrInt(yay,3))")
-            for {
-              _ <- d.act_(Simulate.click(n))
-              _  = d.innerHTML.assert("StrIntWrap(StrInt(yay,11))")
-              _ <- d.act_(Simulate.doubleClick(n))
-              _ <- d.act_(Simulate.click(n))
-            } yield
-              d.innerHTML.assert("StrIntWrap(StrInt(oh,108))")
-          }
-        )          
+        ReactTestUtils2.withRendered(C()) { d =>
+          d.innerHTML.assert("StrIntWrap(StrInt(yay,3))")
+          for {
+            _ <- d.actOnNode_(Simulate.click(_))
+            _  = d.innerHTML.assert("StrIntWrap(StrInt(yay,11))")
+            _ <- d.actOnNode_(Simulate.doubleClick(_))
+            _ <- d.actOnNode_(Simulate.click(_))
+          } yield
+            d.innerHTML.assert("StrIntWrap(StrInt(oh,108))")
+        }    
       }
     }
 

--- a/library/tests/src/test/scala/japgolly/scalajs/react/MiscTest.scala
+++ b/library/tests/src/test/scala/japgolly/scalajs/react/MiscTest.scala
@@ -97,7 +97,7 @@ object MiscTest extends TestSuite {
           .build
         ReactTestUtils2.withRendered(C()) { d =>
           d.select("span").innerHTML.assert("3")
-          Simulation.click run d.node
+          d.node.foreach(Simulation.click.run(_))
           d.select("span").innerHTML.assert("11")
         }
       }

--- a/library/tests/src/test/scala/japgolly/scalajs/react/MiscTest.scala
+++ b/library/tests/src/test/scala/japgolly/scalajs/react/MiscTest.scala
@@ -12,7 +12,7 @@ import scala.scalajs.js
 import scala.util.Try
 import utest._
 
-object MiscTest extends TestSuite {
+object MiscTest extends AsyncTestSuite {
 
   lazy val CA = ScalaComponent.builder[Unit]("CA").render_C(c => <.div(c)).build
   lazy val CB = ScalaComponent.builder[Unit]("CB").render_C(c => <.span(c)).build
@@ -69,9 +69,9 @@ object MiscTest extends TestSuite {
             <.option(^.value := "c")("c"))
         ).build
 
-      ReactTestUtils2.withRenderedSync(s()) { d =>
+      ReactTestUtils2.withRendered_(s()) { d =>
         val sel = d.asSelect()
-        val selectedOptions =sel.options.filter(_.selected).map(_.value)
+        val selectedOptions = sel.options.filter(_.selected).map(_.value)
         assertSet(selectedOptions.toSet, Set("a", "c"))
       }
     }
@@ -95,10 +95,13 @@ object MiscTest extends TestSuite {
             <.button(<.span($.state), ^.onClick --> (add1 >> add7))
           }
           .build
-        ReactTestUtils2.withRenderedSync(C()) { d =>
+        ReactTestUtils2.withRendered(C()) { d =>
           d.select("span").innerHTML.assert("3")
-          d.node.foreach(Simulation.click.run(_))
-          d.select("span").innerHTML.assert("11")
+          d.withNode( n =>
+            d.act_(Simulate.click(n)).map(_ =>
+              d.select("span").innerHTML.assert("11")
+            )
+          )
         }
       }
 
@@ -109,16 +112,21 @@ object MiscTest extends TestSuite {
             val $$ = $.mountedPure.zoomState(_.int)(b => _.copy(int = b))
             val add7 = $$.modState(_ + 7)
             val add1 = $$.modState(_ + 1)
-            <.button(^.onClick --> (add1 >> add7))
+            <.button($.state.toString, ^.onClick --> (add1 >> add7), ^.onDoubleClick --> $.setState(StrInt("oh", 100)))
           }
           .build
-        val c = ReactTestUtils.renderIntoDocument(C())
-        assertEq(c.state, StrInt("yay", 3))
-        Simulation.click run c
-        assertEq(c.state, StrInt("yay", 11))
-        c.setState(StrInt("oh", 100))
-        Simulation.click run c
-        assertEq(c.state, StrInt("oh", 108))
+        ReactTestUtils2.withRendered(C()) ( d =>
+          d.withNode{ n => 
+            d.innerHTML.assert("StrInt(yay,3)")
+            for {
+              _ <- d.act_(Simulate.click(n))
+              _  = d.innerHTML.assert("StrInt(yay,11)")
+              _ <- d.act_(Simulate.doubleClick(n))
+              _ <- d.act_(Simulate.click(n))
+            } yield
+              d.innerHTML.assert("StrInt(oh,108)")
+          }
+        )
       }
 
       "zoomStateL" - {
@@ -128,16 +136,21 @@ object MiscTest extends TestSuite {
             val $$ = $.mountedPure zoomStateL StrInt.int
             val add7 = $$.modState(_ + 7)
             val add1 = $$.modState(_ + 1)
-            <.button(^.onClick --> (add1 >> add7))
+            <.button($.state.toString, ^.onClick --> (add1 >> add7), ^.onDoubleClick --> $.setState(StrInt("oh", 100)))
           }
           .build
-        val c = ReactTestUtils.renderIntoDocument(C())
-        assertEq(c.state, StrInt("yay", 3))
-        Simulation.click run c
-        assertEq(c.state, StrInt("yay", 11))
-        c.setState(StrInt("oh", 100))
-        Simulation.click run c
-        assertEq(c.state, StrInt("oh", 108))
+        ReactTestUtils2.withRendered(C()) { d =>
+          d.withNode{ n => 
+            d.innerHTML.assert("StrInt(yay,3)")
+            for {
+              _ <- d.act_(Simulate.click(n))
+              _  = d.innerHTML.assert("StrInt(yay,11)")
+              _ <- d.act_(Simulate.doubleClick(n))
+              _ <- d.act_(Simulate.click(n))
+            } yield
+              d.innerHTML.assert("StrInt(oh,108)")
+          }
+        }
       }
 
       "zoomStateL2" - {
@@ -147,16 +160,21 @@ object MiscTest extends TestSuite {
             val $$ = $.mountedPure zoomStateL StrIntWrap.strInt zoomStateL StrInt.int
             val add7 = $$.modState(_ + 7)
             val add1 = $$.modState(_ + 1)
-            <.button(^.onClick --> (add1 >> add7))
+            <.button($.state.toString, ^.onClick --> (add1 >> add7), ^.onDoubleClick --> $.setState(StrIntWrap(StrInt("oh", 100))))
           }
           .build
-        val c = ReactTestUtils.renderIntoDocument(C())
-        assertEq(c.state, StrIntWrap(StrInt("yay", 3)))
-        Simulation.click run c
-        assertEq(c.state, StrIntWrap(StrInt("yay", 11)))
-        c.setState(StrIntWrap(StrInt("oh", 100)))
-        Simulation.click run c
-        assertEq(c.state, StrIntWrap(StrInt("oh", 108)))
+        ReactTestUtils2.withRendered(C()) ( d =>
+          d.withNode{ n => 
+            d.innerHTML.assert("StrIntWrap(StrInt(yay,3))")
+            for {
+              _ <- d.act_(Simulate.click(n))
+              _  = d.innerHTML.assert("StrIntWrap(StrInt(yay,11))")
+              _ <- d.act_(Simulate.doubleClick(n))
+              _ <- d.act_(Simulate.click(n))
+            } yield
+              d.innerHTML.assert("StrIntWrap(StrInt(oh,108))")
+          }
+        )          
       }
     }
 
@@ -197,15 +215,16 @@ object MiscTest extends TestSuite {
             <.div("i = ", i)
           )
         ).build
-      ReactTestUtils2.withRenderedSync(comp(234)) { d =>
+      ReactTestUtils2.withRendered_(comp(234))( d =>
         d.outerHTML.assert("<div>i = 234</div>")
+      ).map{ _ =>
+        assertEq(results.length, 1)
+        val r = results.head
+        assertEq(r.id, "blah")
+        assertEq(r.phase, "mount")
+        assertEq(r.phaseIsMount, true)
+        assertEq(r.phaseIsUpdate, false)
       }
-      assertEq(results.length, 1)
-      val r = results.head
-      assertEq(r.id, "blah")
-      assertEq(r.phase, "mount")
-      assertEq(r.phaseIsMount, true)
-      assertEq(r.phaseIsUpdate, false)
     }
 
     "durationFromDOMHighResTimeStamp" - {

--- a/library/tests/src/test/scala/japgolly/scalajs/react/MiscTest.scala
+++ b/library/tests/src/test/scala/japgolly/scalajs/react/MiscTest.scala
@@ -69,7 +69,7 @@ object MiscTest extends TestSuite {
             <.option(^.value := "c")("c"))
         ).build
 
-      ReactTestUtils2.withRendered(s()) { d =>
+      ReactTestUtils2.withRenderedSync(s()) { d =>
         val sel = d.asSelect()
         val selectedOptions =sel.options.filter(_.selected).map(_.value)
         assertSet(selectedOptions.toSet, Set("a", "c"))
@@ -95,7 +95,7 @@ object MiscTest extends TestSuite {
             <.button(<.span($.state), ^.onClick --> (add1 >> add7))
           }
           .build
-        ReactTestUtils2.withRendered(C()) { d =>
+        ReactTestUtils2.withRenderedSync(C()) { d =>
           d.select("span").innerHTML.assert("3")
           d.node.foreach(Simulation.click.run(_))
           d.select("span").innerHTML.assert("11")
@@ -197,7 +197,7 @@ object MiscTest extends TestSuite {
             <.div("i = ", i)
           )
         ).build
-      ReactTestUtils2.withRendered(comp(234)) { d =>
+      ReactTestUtils2.withRenderedSync(comp(234)) { d =>
         d.outerHTML.assert("<div>i = 234</div>")
       }
       assertEq(results.length, 1)

--- a/library/tests/src/test/scala/japgolly/scalajs/react/core/HooksTest.scala
+++ b/library/tests/src/test/scala/japgolly/scalajs/react/core/HooksTest.scala
@@ -16,10 +16,10 @@ import utest._
 object HooksTest extends TestSuite {
 
   protected[core] def test[A](u: Unmounted)(f: DomTester => A): A =
-    withRendered(u).map(d => new DomTester(d.root.asHtml()))(f)
+    withRenderedSync(u).map(d => new DomTester(d.root.asHtml()))(f)
 
   protected[core] def testWithRoot[A](u: Unmounted)(f: (TestReactRoot, DomTester) => A): A =
-    withRendered(u)(d => f(d.root, new DomTester(d.root.asHtml())))
+    withRenderedSync(u)(d => f(d.root, new DomTester(d.root.asHtml())))
 
   private val incBy1 = Reusable.byRef((_: Int) + 1)
   private val incBy5 = Reusable.byRef((_: Int) + 5)
@@ -1957,13 +1957,13 @@ object HooksTest extends TestSuite {
 
     testWithRoot(wrapper(PI(3))) { (r, t) =>
       t.assertText("P=PI(3), S=20, ES=5, R=1")
-      r.render(wrapper(PI(2))); t.assertText("P=PI(3), S=20, ES=5, R=1")
+      r.renderSync(wrapper(PI(2))); t.assertText("P=PI(3), S=20, ES=5, R=1")
       t.clickButton(1); t.assertText("P=PI(2), S=21, ES=5, R=2")
-      r.render(wrapper(PI(2))); t.assertText("P=PI(2), S=21, ES=5, R=2")
-      r.render(wrapper(PI(3))); t.assertText("P=PI(2), S=21, ES=5, R=2")
-      r.render(wrapper(PI(4))); t.assertText("P=PI(4), S=21, ES=5, R=3")
+      r.renderSync(wrapper(PI(2))); t.assertText("P=PI(2), S=21, ES=5, R=2")
+      r.renderSync(wrapper(PI(3))); t.assertText("P=PI(2), S=21, ES=5, R=2")
+      r.renderSync(wrapper(PI(4))); t.assertText("P=PI(4), S=21, ES=5, R=3")
       t.clickButton(2); t.assertText("P=PI(4), S=21, ES=6, R=4")
-      r.render(wrapper(PI(5))); t.assertText("P=PI(4), S=21, ES=6, R=4")
+      r.renderSync(wrapper(PI(5))); t.assertText("P=PI(4), S=21, ES=6, R=4")
     }
   }
 
@@ -2173,7 +2173,7 @@ object HooksTest extends TestSuite {
 
       testWithRoot(comp()) { (r, t) =>
         t.assertText("i=0")
-        r.act(store.inc(true).runNow())
+        r.actSync(store.inc(true).runNow())
         t.assertText("i=1")
       }
       assert(store.peekListener(true).isEmpty)
@@ -2192,7 +2192,7 @@ object HooksTest extends TestSuite {
 
       testWithRoot(comp(false)) { (r, t) =>
         t.assertText("i=0")
-        r.act(store.inc(false).runNow())
+        r.actSync(store.inc(false).runNow())
         t.assertText("i=1")
       }
       assert(store.peekListener(true).isEmpty)
@@ -2210,7 +2210,7 @@ object HooksTest extends TestSuite {
 
       testWithRoot(comp()) { (r, t) =>
         t.assertText("i=0")
-        r.act(store.inc(true).runNow())
+        r.actSync(store.inc(true).runNow())
         t.assertText("i=1")
       }
       assert(store.peekListener(true).isEmpty)

--- a/library/tests/src/test/scala/japgolly/scalajs/react/core/HooksTest.scala
+++ b/library/tests/src/test/scala/japgolly/scalajs/react/core/HooksTest.scala
@@ -13,7 +13,7 @@ import scala.collection.mutable
 import scala.scalajs.js
 import utest._
 
-object HooksTest extends TestSuite {
+object HooksTest extends AsyncTestSuite {
 
   protected[core] def test[A](u: Unmounted)(f: DomTester => A): A =
     withRenderedSync(u).map(d => new DomTester(d.root.asHtml()))(f)

--- a/library/tests/src/test/scala/japgolly/scalajs/react/core/RenderableTest.scala
+++ b/library/tests/src/test/scala/japgolly/scalajs/react/core/RenderableTest.scala
@@ -10,7 +10,7 @@ import utest._
 object RenderableTest extends TestSuite {
 
   private def test[A: Renderable](source: A, expectHtml: String)(implicit l: Line): Unit =
-    ReactTestUtils2.withRendered(source) { r =>
+    ReactTestUtils2.withRenderedSync(source) { r =>
       r.outerHTML.assert(expectHtml)
     }
 

--- a/library/tests/src/test/scala/japgolly/scalajs/react/core/RenderableTest.scala
+++ b/library/tests/src/test/scala/japgolly/scalajs/react/core/RenderableTest.scala
@@ -7,10 +7,10 @@ import japgolly.scalajs.react.vdom.html_<^._
 import sourcecode.Line
 import utest._
 
-object RenderableTest extends TestSuite {
+object RenderableTest extends AsyncTestSuite {
 
-  private def test[A: Renderable](source: A, expectHtml: String)(implicit l: Line): Unit =
-    ReactTestUtils2.withRenderedSync(source) { r =>
+  private def test[A: Renderable](source: A, expectHtml: String)(implicit l: Line): AsyncCallback[Unit] =
+    ReactTestUtils2.withRendered_(source) { r =>
       r.outerHTML.assert(expectHtml)
     }
 

--- a/library/tests/src/test/scala/japgolly/scalajs/react/core/vdom/VdomTest.scala
+++ b/library/tests/src/test/scala/japgolly/scalajs/react/core/vdom/VdomTest.scala
@@ -69,18 +69,18 @@ object VdomTest extends AsyncTestSuite {
     }
 
     "portal" - {
-      ReactTestUtils2.withElementSync { portalTarget =>
+      ReactTestUtils2.withElement.use { portalTarget =>
         val comp = ScalaComponent.static("tmp")(
             <.div(
               "Here we go...",
               ReactPortal(<.div("NICE"), portalTarget)
             )
           )
-          ReactTestUtils2.withRenderedSync(comp()) { d =>
-            val compHtml = ReactTestUtils2.removeReactInternals(d.asHtml().outerHTML)
-            val portalHtml = ReactTestUtils2.removeReactInternals(portalTarget.innerHTML)
-            assertEq((compHtml, portalHtml), ("<div>Here we go...</div>", "<div>NICE</div>"))
-          }
+        ReactTestUtils2.withRendered_(comp()) { d =>
+          val compHtml = ReactTestUtils2.removeReactInternals(d.asHtml().outerHTML)
+          val portalHtml = ReactTestUtils2.removeReactInternals(portalTarget.innerHTML)
+          assertEq((compHtml, portalHtml), ("<div>Here we go...</div>", "<div>NICE</div>"))
+        }
       }
     }
 

--- a/library/tests/src/test/scala/japgolly/scalajs/react/core/vdom/VdomTest.scala
+++ b/library/tests/src/test/scala/japgolly/scalajs/react/core/vdom/VdomTest.scala
@@ -69,14 +69,14 @@ object VdomTest extends AsyncTestSuite {
     }
 
     "portal" - {
-      ReactTestUtils2.withElement { portalTarget =>
+      ReactTestUtils2.withElementSync { portalTarget =>
         val comp = ScalaComponent.static("tmp")(
             <.div(
               "Here we go...",
               ReactPortal(<.div("NICE"), portalTarget)
             )
           )
-          ReactTestUtils2.withRendered(comp()) { d =>
+          ReactTestUtils2.withRenderedSync(comp()) { d =>
             val compHtml = ReactTestUtils2.removeReactInternals(d.asHtml().outerHTML)
             val portalHtml = ReactTestUtils2.removeReactInternals(portalTarget.innerHTML)
             assertEq((compHtml, portalHtml), ("<div>Here we go...</div>", "<div>NICE</div>"))
@@ -105,12 +105,12 @@ object VdomTest extends AsyncTestSuite {
           }
           .build
 
-      ReactTestUtils2.withRenderedAsync(c()) { d =>
+      ReactTestUtils2.withRendered_(c()) { d =>
         def txt() = d.asInput().value
         for {
-          _ <- d.actAsync_(SimEvent.Keyboard.Enter.simulateKeyDown(d.asHtml()))
+          _ <- d.act_(SimEvent.Keyboard.Enter.simulateKeyDown(d.asHtml()))
           _ = assertEq(txt(), "enter!")
-          _ <- d.actAsync_(SimEvent.Keyboard.Space.simulateKeyDown(d.asHtml()))
+          _ <- d.act_(SimEvent.Keyboard.Space.simulateKeyDown(d.asHtml()))
           _ = assertEq(txt(), "SPACE!") 
         } yield ()
       }
@@ -131,7 +131,7 @@ object VdomTest extends AsyncTestSuite {
             }
             .build
 
-        ReactTestUtils2.withRenderedAsync_(c()) { _ =>
+        ReactTestUtils2.withRendered_(c()) { _ =>
           assert(value.isInstanceOf[html.Input])
         }.map(_ => assert(value eq null))
       }
@@ -150,7 +150,7 @@ object VdomTest extends AsyncTestSuite {
             }
             .build
 
-        ReactTestUtils2.withRenderedAsync_(c()) { _ =>
+        ReactTestUtils2.withRendered_(c()) { _ =>
           val x = ref.get.runNow()
           assert(x.isDefined)
         }.map(_ => assert(ref.get.runNow().isEmpty))

--- a/library/tests/src/test/scala/japgolly/scalajs/react/extra/BroadcasterTest.scala
+++ b/library/tests/src/test/scala/japgolly/scalajs/react/extra/BroadcasterTest.scala
@@ -23,11 +23,11 @@ object BroadcasterTest extends TestSuite {
     val b = new B
 
     "component" - {
-      ReactTestUtils2.withRendered(C(b)){ d => 
+      ReactTestUtils2.withRenderedSync(C(b)){ d => 
         DomTester.assertText(d.asHtml(), "Got: {}")
-        d.act(b.broadcast(2).runNow())
+        d.actSync(b.broadcast(2).runNow())
         DomTester.assertText(d.asHtml(), "Got: {2}")
-        d.act(b.broadcast(7).runNow())
+        d.actSync(b.broadcast(7).runNow())
         DomTester.assertText(d.asHtml(), "Got: {2,7}")
       }
     }

--- a/library/tests/src/test/scala/japgolly/scalajs/react/extra/BroadcasterTest.scala
+++ b/library/tests/src/test/scala/japgolly/scalajs/react/extra/BroadcasterTest.scala
@@ -1,11 +1,11 @@
 package japgolly.scalajs.react.extra
 
 import japgolly.scalajs.react._
-import japgolly.scalajs.react.test.{DomTester, ReactTestUtils2}
+import japgolly.scalajs.react.test.ReactTestUtils2
 import japgolly.scalajs.react.vdom.html_<^._
 import utest._
 
-object BroadcasterTest extends TestSuite {
+object BroadcasterTest extends AsyncTestSuite {
 
   class B extends Broadcaster[Int] {
     override def broadcast(a: Int): Callback =
@@ -23,12 +23,14 @@ object BroadcasterTest extends TestSuite {
     val b = new B
 
     "component" - {
-      ReactTestUtils2.withRenderedSync(C(b)){ d => 
-        DomTester.assertText(d.asHtml(), "Got: {}")
-        d.actSync(b.broadcast(2).runNow())
-        DomTester.assertText(d.asHtml(), "Got: {2}")
-        d.actSync(b.broadcast(7).runNow())
-        DomTester.assertText(d.asHtml(), "Got: {2,7}")
+      ReactTestUtils2.withRendered(C(b)){ d => 
+        d.innerHTML.assert("Got: {}")
+        for {
+          _ <- d.act_(b.broadcast(2).runNow())
+          _  = d.innerHTML.assert("Got: {2}")
+          _ <- d.act_(b.broadcast(7).runNow())
+          _  = d.innerHTML.assert("Got: {2,7}")
+        } yield ()
       }
     }
 

--- a/library/tests/src/test/scala/japgolly/scalajs/react/extra/BroadcasterTest.scala
+++ b/library/tests/src/test/scala/japgolly/scalajs/react/extra/BroadcasterTest.scala
@@ -1,10 +1,9 @@
 package japgolly.scalajs.react.extra
 
 import japgolly.scalajs.react._
-import japgolly.scalajs.react.test.ReactTestUtils2
+import japgolly.scalajs.react.test.{DomTester, ReactTestUtils2}
 import japgolly.scalajs.react.vdom.html_<^._
 import utest._
-import japgolly.scalajs.react.test.DomTester
 
 object BroadcasterTest extends TestSuite {
 

--- a/library/tests/src/test/scala/japgolly/scalajs/react/extra/BroadcasterTest.scala
+++ b/library/tests/src/test/scala/japgolly/scalajs/react/extra/BroadcasterTest.scala
@@ -1,9 +1,10 @@
 package japgolly.scalajs.react.extra
 
 import japgolly.scalajs.react._
-import japgolly.scalajs.react.test.ReactTestUtils
+import japgolly.scalajs.react.test.ReactTestUtils2
 import japgolly.scalajs.react.vdom.html_<^._
 import utest._
+import japgolly.scalajs.react.test.DomTester
 
 object BroadcasterTest extends TestSuite {
 
@@ -23,12 +24,13 @@ object BroadcasterTest extends TestSuite {
     val b = new B
 
     "component" - {
-      val c = ReactTestUtils.renderIntoDocument(C(b))
-      assert(c.state == Vector())
-      b.broadcast(2).runNow()
-      assert(c.state == Vector(2))
-      b.broadcast(7).runNow()
-      assert(c.state == Vector(2, 7))
+      ReactTestUtils2.withRendered(C(b)){ d => 
+        DomTester.assertText(d.asHtml(), "Got: {}")
+        d.act(b.broadcast(2).runNow())
+        DomTester.assertText(d.asHtml(), "Got: {2}")
+        d.act(b.broadcast(7).runNow())
+        DomTester.assertText(d.asHtml(), "Got: {2,7}")
+      }
     }
 
     "unregister" - {

--- a/library/tests/src/test/scala/japgolly/scalajs/react/test/DomTester.scala
+++ b/library/tests/src/test/scala/japgolly/scalajs/react/test/DomTester.scala
@@ -28,7 +28,7 @@ class DomTester(root: Element) {
     val bs = root.querySelectorAll("button")
     assert(n > 0 && n <= bs.length, s"${bs.length} buttons found (n=$n)")
     val b = bs(n - 1).asInstanceOf[Button]
-    act(Simulate.click(b))
+    actSync(Simulate.click(b))
   }
 
   def assertInputText(expect: String)(implicit l: Line): Unit =
@@ -36,7 +36,7 @@ class DomTester(root: Element) {
 
   def setInputText(t: String): Unit = {
     val i = getInputText()
-    act(SimEvent.Change(t).simulate(i))
+    actSync(SimEvent.Change(t).simulate(i))
   }
 
   def getText: String =

--- a/library/tests/src/test/scala/japgolly/scalajs/react/test/DomTester.scala
+++ b/library/tests/src/test/scala/japgolly/scalajs/react/test/DomTester.scala
@@ -4,6 +4,7 @@ import japgolly.microlibs.testutil.TestUtil._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.test.ReactTestUtils2._
 import japgolly.scalajs.react.test._
+import japgolly.scalajs.react.util.Effect.Async
 import org.scalajs.dom.html.{Button, Element, Input}
 import sourcecode.Line
 
@@ -24,19 +25,19 @@ class DomTester(root: Element) {
   def assertText(expect: String)(implicit l: Line): Unit =
     DomTester.assertText(root, expect)
 
-  def clickButton(n: Int = 1): Unit = {
+  def clickButton[F[_]: Async](n: Int = 1): F[Unit] = {
     val bs = root.querySelectorAll("button")
     assert(n > 0 && n <= bs.length, s"${bs.length} buttons found (n=$n)")
     val b = bs(n - 1).asInstanceOf[Button]
-    actSync(Simulate.click(b))
+    act_(Simulate.click(b))
   }
 
   def assertInputText(expect: String)(implicit l: Line): Unit =
     assertEq(getInputText().value, expect)
 
-  def setInputText(t: String): Unit = {
+  def setInputText[F[_]: Async](t: String): F[Unit] = {
     val i = getInputText()
-    actSync(SimEvent.Change(t).simulate(i))
+    act_(SimEvent.Change(t).simulate(i))
   }
 
   def getText: String =

--- a/library/tests/src/test/scala/japgolly/scalajs/react/test/ReactTestUtilsConfigTest.scala
+++ b/library/tests/src/test/scala/japgolly/scalajs/react/test/ReactTestUtilsConfigTest.scala
@@ -2,46 +2,47 @@ package japgolly.scalajs.react.test
 
 import japgolly.microlibs.testutil.TestUtil._
 import japgolly.scalajs.react._
+import japgolly.scalajs.react.util.Effect
 import japgolly.scalajs.react.test.ReactTestUtilsConfig._
 import japgolly.scalajs.react.vdom.html_<^._
 import org.scalajs.dom.console
 import scala.annotation.nowarn
-import scala.util.Try
 import utest._
 
-object ReactTestUtilsConfigTest extends TestSuite {
+object ReactTestUtilsConfigTest extends AsyncTestSuite {
 
   @nowarn
-  private def api(): Unit = {
+  private def api[F[_]: Effect](): Unit = {
     // Make sure Scala 2 & 3 have the same API
     AroundReact.id
     AroundReact.fatalReactWarnings
     aroundReact.get
     (aroundReact.set _): (AroundReact => Unit)
-    (i: Int) => aroundReact(i): Int
+    (i: Int) => aroundReact[F, Int](Effect[F].pure(i)): F[Int]
   }
 
   override def tests = Tests {
 
-    "api" - api()
+    "api" - api[AsyncCallback]()
 
     "warnings" - {
       "react" - AroundReact.fatalReactWarnings {
         val c = ScalaFnComponent[Int](i => <.p(<.td(s"i = $i")))
-        val t = Try(ReactTestUtils2.withRenderedSync(c(123))(_ => ()))
-        assertEq(t.isFailure, true)
-        t
+        ReactTestUtils2.withRendered_(c(123))(_ => ()).attemptTry.map( t =>
+          assertEq(t.isFailure, true)
+        )
       }
 
       "unlreated" - AroundReact.fatalReactWarnings {
         val c = ScalaFnComponent[Int](i => <.p(s"i = $i"))
-        val t = Try(ReactTestUtils2.withRenderedSync(c(123)) { _ =>
+        ReactTestUtils2.withRendered_(c(123)) { _ =>
           console.info(".")
           console.log(".")
           console.warn(".")
           console.error(".")
-        })
-        assertEq(t.isFailure, false)
+        }.attemptTry.map( t =>
+          assertEq(t.isFailure, false)
+        )
       }
     }
   }

--- a/library/tests/src/test/scala/japgolly/scalajs/react/test/ReactTestUtilsConfigTest.scala
+++ b/library/tests/src/test/scala/japgolly/scalajs/react/test/ReactTestUtilsConfigTest.scala
@@ -28,14 +28,14 @@ object ReactTestUtilsConfigTest extends TestSuite {
     "warnings" - {
       "react" - AroundReact.fatalReactWarnings {
         val c = ScalaFnComponent[Int](i => <.p(<.td(s"i = $i")))
-        val t = Try(ReactTestUtils2.withRendered(c(123))(_ => ()))
+        val t = Try(ReactTestUtils2.withRenderedSync(c(123))(_ => ()))
         assertEq(t.isFailure, true)
         t
       }
 
       "unlreated" - AroundReact.fatalReactWarnings {
         val c = ScalaFnComponent[Int](i => <.p(s"i = $i"))
-        val t = Try(ReactTestUtils2.withRendered(c(123)) { _ =>
+        val t = Try(ReactTestUtils2.withRenderedSync(c(123)) { _ =>
           console.info(".")
           console.log(".")
           console.warn(".")

--- a/library/tests/src/test/scala/japgolly/scalajs/react/test/ReactTestUtilsConfigTest.scala
+++ b/library/tests/src/test/scala/japgolly/scalajs/react/test/ReactTestUtilsConfigTest.scala
@@ -2,8 +2,8 @@ package japgolly.scalajs.react.test
 
 import japgolly.microlibs.testutil.TestUtil._
 import japgolly.scalajs.react._
-import japgolly.scalajs.react.util.Effect
 import japgolly.scalajs.react.test.ReactTestUtilsConfig._
+import japgolly.scalajs.react.util.Effect
 import japgolly.scalajs.react.vdom.html_<^._
 import org.scalajs.dom.console
 import scala.annotation.nowarn

--- a/library/tests/src/test/scala/japgolly/scalajs/react/test/ReactTestVarTest.scala
+++ b/library/tests/src/test/scala/japgolly/scalajs/react/test/ReactTestVarTest.scala
@@ -78,12 +78,12 @@ object ReactTestVarTest extends AsyncTestSuite {
       ReactTestUtils2.withRendered(c(v.stateAccess)) { d =>
         v.onUpdate(d.root.renderSync(c(v.stateAccess)))
         d.outerHTML.assert("<div>1</div>")
-        d.node.map(n => 
+        d.withNode(n => 
           d.act_(Simulate.click(n)).map{ _ =>
             assertEq(v.value(), 2)
             d.outerHTML.assert("<div>2</div>")
           }
-        ).getOrElse(AsyncCallback.unit)
+        )
       }
     }
   }

--- a/library/tests/src/test/scala/japgolly/scalajs/react/test/ReactTestVarTest.scala
+++ b/library/tests/src/test/scala/japgolly/scalajs/react/test/ReactTestVarTest.scala
@@ -5,7 +5,7 @@ import japgolly.scalajs.react.test.TestUtil._
 import japgolly.scalajs.react.vdom.html_<^._
 import utest._
 
-object ReactTestVarTest extends TestSuite {
+object ReactTestVarTest extends AsyncTestSuite {
 
   override def tests = Tests {
 
@@ -75,12 +75,15 @@ object ReactTestVarTest extends TestSuite {
         .render_P(parent => <.div(parent.state.runNow(), ^.onClick --> parent.modState(_ + 1)))
         .build
       val v = ReactTestVar(1)
-      ReactTestUtils2.withRenderedSync(c(v.stateAccess)) { d =>
+      ReactTestUtils2.withRendered(c(v.stateAccess)) { d =>
         v.onUpdate(d.root.renderSync(c(v.stateAccess)))
         d.outerHTML.assert("<div>1</div>")
-        d.node.foreach(n => d.actSync(Simulate.click(n)))
-        assertEq(v.value(), 2)
-        d.outerHTML.assert("<div>2</div>")
+        d.node.map(n => 
+          d.act_(Simulate.click(n)).map{ _ =>
+            assertEq(v.value(), 2)
+            d.outerHTML.assert("<div>2</div>")
+          }
+        ).getOrElse(AsyncCallback.unit)
       }
     }
   }

--- a/library/tests/src/test/scala/japgolly/scalajs/react/test/ReactTestVarTest.scala
+++ b/library/tests/src/test/scala/japgolly/scalajs/react/test/ReactTestVarTest.scala
@@ -78,12 +78,10 @@ object ReactTestVarTest extends AsyncTestSuite {
       ReactTestUtils2.withRendered(c(v.stateAccess)) { d =>
         v.onUpdate(d.root.renderSync(c(v.stateAccess)))
         d.outerHTML.assert("<div>1</div>")
-        d.withNode(n => 
-          d.act_(Simulate.click(n)).map{ _ =>
-            assertEq(v.value(), 2)
-            d.outerHTML.assert("<div>2</div>")
-          }
-        )
+        d.actOnNode_(Simulate.click(_)).map{ _ =>
+          assertEq(v.value(), 2)
+          d.outerHTML.assert("<div>2</div>")
+        }
       }
     }
   }

--- a/library/tests/src/test/scala/japgolly/scalajs/react/test/ReactTestVarTest.scala
+++ b/library/tests/src/test/scala/japgolly/scalajs/react/test/ReactTestVarTest.scala
@@ -75,10 +75,10 @@ object ReactTestVarTest extends TestSuite {
         .render_P(parent => <.div(parent.state.runNow(), ^.onClick --> parent.modState(_ + 1)))
         .build
       val v = ReactTestVar(1)
-      ReactTestUtils2.withRendered(c(v.stateAccess)) { d =>
-        v.onUpdate(d.root.render(c(v.stateAccess)))
+      ReactTestUtils2.withRenderedSync(c(v.stateAccess)) { d =>
+        v.onUpdate(d.root.renderSync(c(v.stateAccess)))
         d.outerHTML.assert("<div>1</div>")
-        d.node.foreach(n => d.act(Simulate.click(n)))
+        d.node.foreach(n => d.actSync(Simulate.click(n)))
         assertEq(v.value(), 2)
         d.outerHTML.assert("<div>2</div>")
       }

--- a/library/tests/src/test/scala/japgolly/scalajs/react/test/ReactTestVarTest.scala
+++ b/library/tests/src/test/scala/japgolly/scalajs/react/test/ReactTestVarTest.scala
@@ -75,12 +75,12 @@ object ReactTestVarTest extends TestSuite {
         .render_P(parent => <.div(parent.state.runNow(), ^.onClick --> parent.modState(_ + 1)))
         .build
       val v = ReactTestVar(1)
-      ReactTestUtils.withRenderedIntoDocument(c(v.stateAccess)) { m =>
-        v.onUpdate(m.forceUpdate)
-        assertRendered(m.getDOMNode.asMounted().asElement(), "<div>1</div>")
-        Simulate.click(m.getDOMNode.asMounted().asElement())
+      ReactTestUtils2.withRendered(c(v.stateAccess)) { d =>
+        v.onUpdate(d.root.render(c(v.stateAccess)))
+        d.outerHTML.assert("<div>1</div>")
+        d.node.foreach(n => d.act(Simulate.click(n)))
         assertEq(v.value(), 2)
-        assertRendered(m.getDOMNode.asMounted().asElement(), "<div>2</div>")
+        d.outerHTML.assert("<div>2</div>")
       }
     }
   }

--- a/library/tests/src/test/scala/japgolly/scalajs/react/test/TestTest.scala
+++ b/library/tests/src/test/scala/japgolly/scalajs/react/test/TestTest.scala
@@ -11,7 +11,7 @@ import scala.concurrent.Promise
 import scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 import utest._
 
-object TestTest extends TestSuite {
+object TestTest extends AsyncTestSuite {
 
   lazy val A = ScalaComponent.builder[Unit]("A").render_C(c => <.p(^.cls := "AA", c)).build
   lazy val B = ScalaComponent.builder[Unit]("B").renderStatic(<.p(^.cls := "BB", "hehehe")).build
@@ -47,13 +47,13 @@ object TestTest extends TestSuite {
 
     "withRendered" - {
 
-      "plainElement" - ReactTestUtils2.withRendered(<.div("Good")) { r =>
+      "plainElement" - ReactTestUtils2.withRenderedSync(<.div("Good")) { r =>
         r.outerHTML.assert("<div>Good</div>")
         r.innerHTML.assert("Good")
         r.root.outerHTML.assert("<div><div>Good</div></div>")
       }
 
-      "scalaComponent" - ReactTestUtils2.withRendered(B()) { r =>
+      "scalaComponent" - ReactTestUtils2.withRenderedSync(B()) { r =>
         r.outerHTML.assert("""<p class="BB">hehehe</p>""")
         r.innerHTML.assert("""hehehe""")
         r.root.outerHTML.assert("""<div><p class="BB">hehehe</p></div>""")
@@ -63,7 +63,7 @@ object TestTest extends TestSuite {
     "Simulate" - {
 
       "click" - {
-        ReactTestUtils2.withRendered(IC()) { r =>
+        ReactTestUtils2.withRenderedSync(IC()) { r =>
           def s = r.querySelector("span")
           val a = s.innerHTML
           Simulate.click(inputRef.unsafeGet())
@@ -82,7 +82,7 @@ object TestTest extends TestSuite {
             )
           }).build
 
-          ReactTestUtils2.withRendered(IDC()) { r =>
+          ReactTestUtils2.withRenderedSync(IDC()) { r =>
             def s = r.querySelector("span")
             val a = s.innerHTML
             simF(inputRef.unsafeGet())
@@ -170,13 +170,13 @@ object TestTest extends TestSuite {
           }
           <.div(^.onClick ==> onClick)
         }.build
-        ReactTestUtils2.withRendered(c()) { r =>
+        ReactTestUtils2.withRenderedSync(c()) { r =>
           r.node.foreach(Simulate.click(_))
         }
         assertEq(ok, true)
       }
 
-      "change" - ReactTestUtils2.withRendered(IT()) { t =>
+      "change" - ReactTestUtils2.withRenderedSync(IT()) { t =>
         t.node.foreach(SimEvent.Change("hehe").simulate(_))
         assertEq(t.asInput().value, "HEHE")
       }
@@ -189,14 +189,14 @@ object TestTest extends TestSuite {
             e("change") >> T.setState(ev.target.value)
           <.input.text(^.value := T.state, ^.onFocus --> e("focus"), ^.onChange ==> chg, ^.onBlur --> e("blur")).withRef(inputRef)
         }).build
-        ReactTestUtils2.withRendered(C()) { _ =>
+        ReactTestUtils2.withRenderedSync(C()) { _ =>
           Simulation.focusChangeBlur("good") run inputRef.unsafeGet()
           assertEq(events, Vector("focus", "change", "blur"))
           assertEq(inputRef.unsafeGet().value, "good")
         }
       }
 
-      "targetByName" - ReactTestUtils2.withRendered(IC()) { t =>
+      "targetByName" - ReactTestUtils2.withRenderedSync(IC()) { t =>
         var count = 0
         def tgt = {
           count += 1
@@ -210,7 +210,7 @@ object TestTest extends TestSuite {
     "withRendered" - {
       def inspectBody() = document.body.childElementCount
       val body1 = inspectBody()
-      ReactTestUtils2.withRendered(IC()) { t =>
+      ReactTestUtils2.withRenderedSync(IC()) { t =>
         t.outerHTML.assertStartsWith("<label><input ")
         assertNotEq(body1, inspectBody())
 
@@ -226,7 +226,7 @@ object TestTest extends TestSuite {
     "withRenderedFuture" - {
       var r: TestReactRoot = null
       val promise: Promise[Unit] = Promise[Unit]()
-      val future = ReactTestUtils2.withRendered(IC()).future { t =>
+      val future = ReactTestUtils2.withRenderedSync(IC()).future { t =>
         r = t.root
         assertEq(r.isEmpty(), false)
         t.outerHTML.assertStartsWith("<label><input ")
@@ -238,17 +238,17 @@ object TestTest extends TestSuite {
       future.map { _ => assertEq(r.isEmpty(), true) }
     }
 
-    "replaceProps" - ReactTestUtils2.withRendered(CP("start")) { d =>
+    "replaceProps" - ReactTestUtils2.withRenderedSync(CP("start")) { d =>
       d.outerHTML.assert("<div>none → start</div>")
-      d.root.render(CP("started"))
+      d.root.renderSync(CP("started"))
       d.outerHTML.assert("<div>start → started</div>")
-      d.root.render(CP("done!"))
+      d.root.renderSync(CP("done!"))
       d.outerHTML.assert("<div>started → done!</div>")
     }
 
     "removeReactInternals" - {
       val c = ScalaComponent.static("")(<.div(<.br, "hello", <.hr))
-      ReactTestUtils2.withRendered(c()) { t =>
+      ReactTestUtils2.withRenderedSync(c()) { t =>
         // val orig = t.asHtml().outerHTML
         // val after = ReactTestUtils2.removeReactInternals(orig)
         // assertEq("<div><br>hello<hr></div>", after)
@@ -260,10 +260,9 @@ object TestTest extends TestSuite {
     "act" - {
       // Just making sure the facade and types align
       var called = false
-      ReactTestUtils2.act {
+      ReactTestUtils2.act_ {
         called = true
-      }
-      assertEq(called, true)
+      }.map(_ => assertEq(called, true))
     }
 
     // Disabled due to https://github.com/scala-js/scala-js-env-jsdom-nodejs/issues/44

--- a/library/tests/src/test/scala/japgolly/scalajs/react/test/TestTest.scala
+++ b/library/tests/src/test/scala/japgolly/scalajs/react/test/TestTest.scala
@@ -171,13 +171,13 @@ object TestTest extends TestSuite {
           <.div(^.onClick ==> onClick)
         }.build
         ReactTestUtils2.withRendered(c()) { r =>
-          Simulate.click(r.node)
+          r.node.foreach(Simulate.click(_))
         }
         assertEq(ok, true)
       }
 
       "change" - ReactTestUtils2.withRendered(IT()) { t =>
-        SimEvent.Change("hehe").simulate(t.node)
+        t.node.foreach(SimEvent.Change("hehe").simulate(_))
         assertEq(t.asInput().value, "HEHE")
       }
 
@@ -200,7 +200,7 @@ object TestTest extends TestSuite {
         var count = 0
         def tgt = {
           count += 1
-          t.select("input").node
+          t.select("input").node.get
         }
         Simulation.focusChangeBlur("-") run tgt
         assertEq(count, 3)

--- a/library/tests/src/test/scala/japgolly/scalajs/react/test/TestUtil.scala
+++ b/library/tests/src/test/scala/japgolly/scalajs/react/test/TestUtil.scala
@@ -115,7 +115,7 @@ trait TestUtil
   }
 
   def assertRendered(n: TopNode, expected: String)(implicit l: Line): Unit = {
-    val rendered: String = ReactTestUtils.removeReactInternals(n.outerHTML)
+    val rendered: String = ReactTestUtils2.removeReactInternals(n.outerHTML)
     assertEq(rendered, expected)
   }
 

--- a/library/util/src/main/scala/japgolly/scalajs/react/util/Effect.scala
+++ b/library/util/src/main/scala/japgolly/scalajs/react/util/Effect.scala
@@ -20,6 +20,7 @@ trait Effect[F[_]] extends Monad[F] {
 }
 
 object Effect extends EffectFallbacks {
+  @inline def apply[F[_]](implicit F: Effect[F]): Effect[F] = F
 
   trait WithDefaults[F[_]] extends Effect[F] {
   }

--- a/library/util/src/main/scala/japgolly/scalajs/react/util/Monad.scala
+++ b/library/util/src/main/scala/japgolly/scalajs/react/util/Monad.scala
@@ -5,6 +5,8 @@ trait Monad[F[_]] {
   def map    [A, B](fa: F[A])(f: A => B)   : F[B]
   def flatMap[A, B](fa: F[A])(f: A => F[B]): F[B]
 
+  val unit: F[Unit] = pure(())
+
   def tailrec[A, B](a: A)(f: A => F[Either[A, B]]): F[B]
 
   def chain[A, B](fa: F[A], fb: F[B]): F[B] =


### PR DESCRIPTION
This PR is a step forward into removing `ReactTestUtils` in favor of the newer `ReactTestUtils2` (which will be renamed once the former is removed).

It also removes all uses of the sync version of `act` in favor of the async one, given that the React docs specify that:

```
We recommend using act with await and an async function. Although the sync version works in many cases, it doesn’t work in all cases and due to the way React schedules updates internally, it’s difficult to predict when you can use the sync version.

We will deprecate and remove the sync version in the future.
```

A number of scaffolding code was also implemented:
- `AsyncTestSuite` allows running tests that return an `AsyncCallback` and runs them. This is not published but rather copied and pasted whenever it's used. I'm not sure where to place it and it would probably need to be in its own `scalajs-react-utest-acb` bundle.
- `polyfill.js` now provides access to `MessageChannel`, which allows executing `async`/`await` within `jsdom`. Again, this is copied in the few test project where it is used.
- `Resource` implements a managed resource. It is a generic (and therefore async) version of `WithDsl`. I think `WithDsl` can be replaced in the future with `Resource[Id]`. However, we may end up deprecating and removing `WithDsl` together with the sync version of `act`. This class only lives in the testing utils project, but it may be useful for other things (like `AroundReact`). If we decide to adopt it for client use, we may want to polish it up a bit. Eg: build an AST and then interpret it, rather than using `var`s, and making sure it is stack safe.

The few places where `ReactTestUtils` is still used is where class components are tested. These tests need access to the mounted versions of the components, which the modern testing framework doesn't seem to provide. Probably the course of action here will be just to remove these tests, or move them all, together with `ReactTestUtils` to a `tests-legacy` project. I'm open to suggestions.
