### PR TITLE
Bugfix: `<.div(1: js.UndefOr[Int])` now compiles with Scala 3

### DIFF
--- a/doc/changelog/4.0.0.md
+++ b/doc/changelog/4.0.0.md
@@ -33,6 +33,7 @@ React itself no longer provides UMD builds so either
 
 * Delete all deprecated code — ensure you update to 3.0.0 and resolve deprecation warnings before upgrading to 4.0.0
 * Upgrade Cats Effect to 3.7.0
+* Bugfix: `<.div(1: js.UndefOr[Int])` now compiles with Scala 3
 
 ## Support
 

--- a/library/coreGeneric/src/main/scala-3/japgolly/scalajs/react/vdom/VdomNode.scala
+++ b/library/coreGeneric/src/main/scala-3/japgolly/scalajs/react/vdom/VdomNode.scala
@@ -30,6 +30,8 @@ trait VdomNodeScalaSpecificImplicits {
   inline implicit def vdomNodeFromRawReactNode(v: facade.React.Node)(using
       inline evU: NotGiven[v.type <:< Unit],
       inline evB: NotGiven[v.type <:< Boolean],
+      inline evO: NotGiven[v.type <:< scala.scalajs.js.UndefOr[Any]],
+      inline evP: NotGiven[v.type <:< Option[Any]],
     ): VdomNode =
     VdomNode(v)
 }

--- a/library/tests/src/test/scala/japgolly/scalajs/react/core/vdom/PrefixedTest.scala
+++ b/library/tests/src/test/scala/japgolly/scalajs/react/core/vdom/PrefixedTest.scala
@@ -37,7 +37,7 @@ object PrefixedTest extends TestSuite {
 
     "inner" - {
       "undefined" - test(<.div(js.undefined),        """<div></div>""")
-      // "jsDefined" - test(<.div(1: js.UndefOr[Int]),  """<div>1</div>""") // issue #1123
+      "jsDefined" - test(<.div(1: js.UndefOr[Int]),  """<div>1</div>""")
       "byte"      - test(<.div(50: Byte),            """<div>50</div>""")
       "short"     - test(<.div(45: Short),           """<div>45</div>""")
       "int"       - test(<.div(666),                 """<div>666</div>""")


### PR DESCRIPTION
Fixes #1123