### PR TITLE
Add support for `getDerivedStateFromError`

### DIFF
--- a/doc/changelog/4.0.0.md
+++ b/doc/changelog/4.0.0.md
@@ -34,6 +34,7 @@ React itself no longer provides UMD builds so either
 * Delete all deprecated code — ensure you update to 3.0.0 and resolve deprecation warnings before upgrading to 4.0.0
 * Upgrade Cats Effect to 3.7.0
 * Bugfix: `<.div(1: js.UndefOr[Int])` now compiles with Scala 3
+* Add support for `getDerivedStateFromError`
 
 ## Support
 

--- a/library/coreGeneric/src/main/scala-2/japgolly/scalajs/react/component/builder/ComponentBuilder.scala
+++ b/library/coreGeneric/src/main/scala-2/japgolly/scalajs/react/component/builder/ComponentBuilder.scala
@@ -8,6 +8,7 @@ import japgolly.scalajs.react.util.Effect._
 import japgolly.scalajs.react.util.Semigroup
 import japgolly.scalajs.react.vdom.VdomNode
 import japgolly.scalajs.react.{Children, CtorType, PropsChildren, UpdateSnapshot, facade}
+import scala.scalajs.js
 
 object ComponentBuilder {
   import Lifecycle._
@@ -267,6 +268,34 @@ object ComponentBuilder {
      */
     def componentWillUnmount[G[_]](f: ComponentWillUnmount[P, S, B] => G[Unit])(implicit G: Dispatch[G]): This =
       lcAppendDispatch(LifecycleF.componentWillUnmount)(f)
+
+    /** getDerivedStateFromError is invoked after an error has been thrown by a descendant component.
+      * It receives the error that was thrown as a parameter and should return a value to update state.
+      *
+      * Note: getDerivedStateFromError is called during the “render” phase, so side-effects are not permitted.
+      * For those use cases, use componentDidCatch instead.
+      */
+    def getDerivedStateFromError(f: js.Any => S): This =
+      getDerivedStateFromErrorOption(e => Some(f(e)))
+
+    /** getDerivedStateFromError is invoked after an error has been thrown by a descendant component.
+      * It receives the error that was thrown as a parameter and should return a value to update state,
+      * or None to update nothing.
+      *
+      * Note: getDerivedStateFromError is called during the “render” phase, so side-effects are not permitted.
+      * For those use cases, use componentDidCatch instead.
+      */
+    def getDerivedStateFromErrorOption(f: js.Any => Option[S]): This = {
+      val update: Lifecycle_ => Lifecycle_ =
+        LifecycleF.getDerivedStateFromError.mod {
+          case None => Some(f)
+          case Some(prev) =>
+            Some { e =>
+              f(e).orElse(prev(e))
+            }
+        }
+      copy(lifecycle = update(lifecycle))
+    }
 
     /** getDerivedStateFromProps is invoked right before calling the render method, both on the initial mount and on
       * subsequent updates.

--- a/library/coreGeneric/src/main/scala-3/japgolly/scalajs/react/component/builder/ComponentBuilder.scala
+++ b/library/coreGeneric/src/main/scala-3/japgolly/scalajs/react/component/builder/ComponentBuilder.scala
@@ -11,6 +11,7 @@ import japgolly.scalajs.react.vdom.VdomNode
 import japgolly.scalajs.react.{Children, CtorType, PropsChildren, UpdateSnapshot, facade}
 import scala.annotation.nowarn
 import scala.language.`3.0`
+import scala.scalajs.js
 
 object ComponentBuilder {
 
@@ -267,6 +268,34 @@ object ComponentBuilder {
      */
     def componentWillUnmount[G[_]](f: ComponentWillUnmount[P, S, B] => G[Unit])(implicit G: Dispatch[G]): This =
       lcAppendDispatch(LifecycleF.componentWillUnmount)(f)
+
+    /** getDerivedStateFromError is invoked after an error has been thrown by a descendant component.
+      * It receives the error that was thrown as a parameter and should return a value to update state.
+      *
+      * Note: getDerivedStateFromError is called during the “render” phase, so side-effects are not permitted.
+      * For those use cases, use componentDidCatch instead.
+      */
+    def getDerivedStateFromError(f: js.Any => S): This =
+      getDerivedStateFromErrorOption(e => Some(f(e)))
+
+    /** getDerivedStateFromError is invoked after an error has been thrown by a descendant component.
+      * It receives the error that was thrown as a parameter and should return a value to update state,
+      * or None to update nothing.
+      *
+      * Note: getDerivedStateFromError is called during the “render” phase, so side-effects are not permitted.
+      * For those use cases, use componentDidCatch instead.
+      */
+    def getDerivedStateFromErrorOption(f: js.Any => Option[S]): This = {
+      val update: Lifecycle_ => Lifecycle_ =
+        LifecycleF.getDerivedStateFromError.mod {
+          case None => Some(f)
+          case Some(prev) =>
+            Some { e =>
+              f(e).orElse(prev(e))
+            }
+        }
+      copy(lifecycle = update(lifecycle))
+    }
 
     /** getDerivedStateFromProps is invoked right before calling the render method, both on the initial mount and on
       * subsequent updates.

--- a/library/coreGeneric/src/main/scala/japgolly/scalajs/react/component/builder/LifecycleF.scala
+++ b/library/coreGeneric/src/main/scala/japgolly/scalajs/react/component/builder/LifecycleF.scala
@@ -19,6 +19,7 @@ final case class LifecycleF[F[_], A[_], P, S, B, SS](
       componentWillReceiveProps: Option[ComponentWillReceivePropsFn[F, A, P, S, B]],
       componentWillUnmount     : Option[ComponentWillUnmountFn     [F, A, P, S, B]],
       componentWillUpdate      : Option[ComponentWillUpdateFn      [F, A, P, S, B]],
+      getDerivedStateFromError : Option[GetDerivedStateFromErrorFn [      S]],
       getDerivedStateFromProps : Option[GetDerivedStateFromPropsFn [   P, S]],
       getSnapshotBeforeUpdate  : Option[GetSnapshotBeforeUpdateFn  [F, A, P, S, B, SS]],
       shouldComponentUpdate    : Option[ShouldComponentUpdateFn    [F, A, P, S, B]]) {
@@ -38,6 +39,7 @@ final case class LifecycleF[F[_], A[_], P, S, B, SS](
       componentWillReceiveProps = componentWillReceiveProps,
       componentWillUnmount      = componentWillUnmount     ,
       componentWillUpdate       = componentWillUpdate      ,
+      getDerivedStateFromError  = getDerivedStateFromError ,
       getDerivedStateFromProps  = getDerivedStateFromProps ,
       getSnapshotBeforeUpdate   = getSnapshotBeforeUpdate  ,
       shouldComponentUpdate     = shouldComponentUpdate    )
@@ -47,7 +49,7 @@ object LifecycleF {
   type NoSnapshot = Unit
 
   def empty[F[_], A[_], P, S, B]: LifecycleF[F, A, P, S, B, NoSnapshot] =
-    new LifecycleF(None, None, None, None, None, None, None, None, None, None)
+    new LifecycleF(None, None, None, None, None, None, None, None, None, None, None)
 
   sealed abstract class Base[F[_], A[_], P, S, B](final val raw: RawMounted[P, S, B])(implicit f: UnsafeSync[F], a: Async[A]) {
     protected final implicit def F: UnsafeSync[F] = f
@@ -262,6 +264,12 @@ object LifecycleF {
     @deprecated("forceUpdate prohibited within the componentWillUpdate callback. Use componentWillReceiveProps instead.", "")
     def forceUpdate(no: NotAllowed) = no.result
   }
+
+  // ===================================================================================================================
+
+  def getDerivedStateFromError[F[_], A[_], P, S, B, SS] = Lens((_: LifecycleF[F, A, P, S, B, SS]).getDerivedStateFromError)(n => _.copy(getDerivedStateFromError = n))
+
+  type GetDerivedStateFromErrorFn[S] = js.Any => Option[S]
 
   // ===================================================================================================================
 

--- a/library/coreGeneric/src/main/scala/japgolly/scalajs/react/component/builder/ViaReactComponent.scala
+++ b/library/coreGeneric/src/main/scala/japgolly/scalajs/react/component/builder/ViaReactComponent.scala
@@ -222,6 +222,7 @@ object ViaReactComponent {
 
   private final class StaticProps(val methods: js.Array[Method] = js.Array()) extends AnyVal {
     def add[O](k: String, v: js.Any): Unit = methods.push(Method(k, v))
+    def add1[A, O](k: String, f: A => O): Unit = add(k, f: js.Function1[A, O])
     def add2[A, B, O](k: String, f: (A, B) => O): Unit = add(k, f: js.Function2[A, B, O])
   }
 
@@ -321,6 +322,10 @@ object ViaReactComponent {
     for (f <- builder.lifecycle.componentWillUpdate)
       protoProps.add2("componentWillUpdate",
         (_this: This, p: Box[P], s: Box[S]) => Sync.runSync(f(new ComponentWillUpdate(_this, p.unbox, s.unbox))))
+
+    for (f <- builder.lifecycle.getDerivedStateFromError)
+      staticProps.add1("getDerivedStateFromError",
+        (e: js.Any) => boxStateOrNull(f(e)))
 
     for (f <- builder.lifecycle.getDerivedStateFromProps)
       staticProps.add2("getDerivedStateFromProps",

--- a/library/tests/src/test/scala/japgolly/scalajs/react/core/GetDerivedStateFromErrorTest.scala
+++ b/library/tests/src/test/scala/japgolly/scalajs/react/core/GetDerivedStateFromErrorTest.scala
@@ -1,0 +1,67 @@
+package japgolly.scalajs.react.core
+
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.vdom.html_<^._
+import japgolly.scalajs.react.test.ReactTestUtils
+import japgolly.scalajs.react.test.TestUtil._
+import utest._
+import scala.scalajs.js
+
+object GetDerivedStateFromErrorTest extends TestSuite {
+
+  override def tests = Tests {
+
+    "getDerivedStateFromError" - {
+      val Child = ScalaComponent.builder[Unit]("")
+        .render { _ =>
+          throw new RuntimeException("Heads will roll!")
+          <.div("Child")
+        }
+        .build
+
+      val Parent = ScalaComponent.builder[Unit]("")
+        .initialState(Option.empty[String])
+        .render { $ =>
+          $.state match {
+            case Some(err) => <.div(s"Caught: $err")
+            case None      => Child()
+          }
+        }
+        .getDerivedStateFromError(e => Some(e.toString))
+        .build
+
+      ReactTestUtils.withReactRootSync { root =>
+        // React 18+ might log the error to console even if caught,
+        // and might need multiple renders or act() for error boundaries.
+        // But withReactRootSync and basic render should work.
+        root.renderSync(Parent())
+        root.innerHTML.assert("<div>Caught: java.lang.RuntimeException: Heads will roll!</div>")
+      }
+    }
+
+    "multiple" - {
+      val Child = ScalaComponent.builder[Unit]("")
+        .render { _ =>
+          throw new RuntimeException("error")
+        }
+        .build
+
+      val Parent = ScalaComponent.builder[Unit]("")
+        .initialState(Option.empty[String])
+        .render { $ =>
+          $.state match {
+            case Some(err) => <.div(s"Caught: $err")
+            case None      => Child()
+          }
+        }
+        .getDerivedStateFromError(_ => Some("first"))
+        .getDerivedStateFromError(_ => Some("second"))
+        .build
+
+      ReactTestUtils.withReactRootSync { root =>
+        root.renderSync(Parent())
+        root.innerHTML.assert("<div>Caught: second</div>")
+      }
+    }
+  }
+}


### PR DESCRIPTION
Done completely via AI.

✦ I have added support for getDerivedStateFromError to the library by making the following changes:

   1. LifecycleF.scala: Updated the LifecycleF case class to include a getDerivedStateFromError field, added a lens for it, and updated the empty and resetSnapshot methods to handle the new field.
   2. ComponentBuilder.scala (Scala 2 & 3): Added getDerivedStateFromError and getDerivedStateFromErrorOption methods to the component builder API. These methods allow users to define the static getDerivedStateFromError lifecycle method in a type-safe way. I also added import scala.scalajs.js to provide the necessary types.
   3. ViaReactComponent.scala: Updated the internal component creation logic to attach getDerivedStateFromError to the static properties of the generated React component class.
   4. Tests: Created GetDerivedStateFromErrorTest.scala to verify that getDerivedStateFromError correctly catches errors from child components and updates the state as expected, including support for multiple composed error handlers.

Closes #1076